### PR TITLE
Fix: Resolve team name generation bugs causing player loss

### DIFF
--- a/locale/de/names_de.json
+++ b/locale/de/names_de.json
@@ -1,5 +1,5 @@
 {
-    "adjektive": [
+    "adjectives": [
       "Mutige", "Wilde", "Eiserne", "Schnelle", "Stille", "Kühne", "Tapfere", "Listige",
       "Freche", "Donnernde", "Flinke", "Mächtige", "Verwegene", "Legendäre", "Lustige",
       "Athletische", "Beglückende", "Elegante", "Fabelhafte", "Feurige", "Grandiose",
@@ -11,7 +11,7 @@
       "Sonnige", "Frostige", "Windige", "Gelangweilte", "Unvergängliche", "Unnachgiebige",
       "Saubere", "Einarmige", "Einbeinige", "Imperiale", "Kaiserliche", "Melancholische", "Verwirrte"
     ],
-    "substantive": [
+    "nouns": [
       "Wölfe", "Drachen", "Falken", "Titanen", "Krieger", "Panther", "Schlangen", "Ninjas",
       "Löwen", "Bären", "Adler", "Haie", "Berserker", "Wächter", "Hobbits", "Goblins", "Ratten",
       "Hühner", "Flöten", "Feen", "Orks", "Elfen", "Vampire", "Lappen", "Seepferdchen", "Einhörner",

--- a/modules/matchmaker.py
+++ b/modules/matchmaker.py
@@ -282,14 +282,20 @@ def auto_match_solo():
             team_name = generate_team_name()
             attempts += 1
             if attempts > 10:
-                logger.error("[MATCHMAKER] ❌ No unique team name found – Aborting.")
+                logger.error("[MATCHMAKER] ❌ No unique team name found – Aborting this pairing.")
+                logger.error(f"[MATCHMAKER]    Players {name1} and {name2} will remain in solo queue.")
+                # Return players to solo queue instead of losing them
+                solo_players.append(p1)
+                solo_players.append(p2)
                 break
-        used_names.add(team_name)
+        else:
+            # Only create team if we successfully found a unique name
+            used_names.add(team_name)
 
-        new_teams[team_name] = {
-            "members": [name1, name2],
-            "availability": overlap,
-        }
+            new_teams[team_name] = {
+                "members": [name1, name2],
+                "availability": overlap,
+            }
 
     if new_teams:
         tournament.setdefault("teams", {}).update(new_teams)

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -333,7 +333,7 @@ def finalize_tournament(winning_team: str, winners: list[int], game: str, points
 def generate_team_name(language: str = None) -> str:
     """
     Generates a random team name from adjective and noun lists.
-    If no names are found, a generic name is returned.
+    If no names are found, generates a unique fallback name with UUID.
 
     :param language: Language (optional); default: from config
     :return: Team name as string
@@ -345,7 +345,11 @@ def generate_team_name(language: str = None) -> str:
 
     # Safety check: If file is missing or empty
     if not names or "adjectives" not in names or "nouns" not in names:
-        return "Team_X"
+        import uuid
+        # Generate unique fallback name
+        unique_id = str(uuid.uuid4())[:8]
+        logger.warning(f"[NAMEGEN] Names file missing or empty - using fallback name with ID {unique_id}")
+        return f"Team_{unique_id}"
 
     adjective = random.choice(names["adjectives"])
     noun = random.choice(names["nouns"])


### PR DESCRIPTION
Critical bugs fixed:
1. Team name generator returned same fallback 'Team_X' for all teams
   - Caused duplicate name collisions after first team
   - Now generates unique UUID-based fallback names

2. Players were lost when team name generation failed
   - After 10 failed attempts, players were removed from solo queue but no team was created
   - Now returns players to solo queue if naming fails (using while-else pattern)

3. Language mismatch in names_de.json
   - File used German keys ('adjektive', 'substantive')
   - Code expected English keys ('adjectives', 'nouns')
   - Standardized to English keys for consistency with codebase

Result:
- All 4 solo players now correctly paired into 2 teams
- No more player loss when naming fails
- Proper fallback behavior with unique names