### PR TITLE
Fix: Resolve timezone issues causing negative pause calculations

### DIFF
--- a/modules/dev_tools.py
+++ b/modules/dev_tools.py
@@ -4,6 +4,7 @@ import asyncio
 import random
 import discord
 from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
 from discord import Interaction, app_commands
 from discord.ext import commands
 
@@ -544,12 +545,17 @@ class DevGroup(app_commands.Group):
 
             # Get tournament end date
             from datetime import datetime, timedelta
+            tz = ZoneInfo(CONFIG.bot.timezone)
+
             tournament_end = tournament.get("tournament_end")
             if tournament_end:
                 end_date = datetime.fromisoformat(tournament_end)
+                # Ensure timezone awareness
+                if end_date.tzinfo is None:
+                    end_date = end_date.replace(tzinfo=tz)
             else:
                 # Default: 2 weeks from now
-                end_date = datetime.now() + timedelta(weeks=2)
+                end_date = datetime.now(tz=tz) + timedelta(weeks=2)
 
             # Try to create schedule
             matchups = create_round_robin_schedule(tournament)
@@ -708,8 +714,12 @@ class DevGroup(app_commands.Group):
         reg_end = tournament.get("registration_end")
         if reg_open and reg_end:
             try:
+                tz = ZoneInfo(CONFIG.bot.timezone)
                 dt = datetime.fromisoformat(reg_end)
-                remaining = dt - datetime.now()
+                # Ensure timezone awareness
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=tz)
+                remaining = dt - datetime.now(tz=tz)
                 report.append(f"📝 Registration: ✅ Open ({remaining.days}d {remaining.seconds//3600}h remaining)")
             except Exception:
                 report.append("📝 Registration: ⚠️ Invalid date format")

--- a/modules/poll.py
+++ b/modules/poll.py
@@ -8,6 +8,7 @@ import discord
 from discord.ext import commands
 
 # Local modules
+from modules.config import CONFIG
 from modules.dataStorage import load_tournament_data, save_tournament_data, load_games
 from modules.embeds import send_poll_results, send_registration_open
 from modules.logger import logger
@@ -148,13 +149,16 @@ async def end_poll(bot: discord.Client, channel: discord.TextChannel):
     tournament = load_tournament_data()
     registration_end_str = tournament.get("registration_end")
     if registration_end_str:
+        # Get timezone from config
+        tz = ZoneInfo(CONFIG.bot.timezone)
+
         registration_end = datetime.fromisoformat(registration_end_str)
 
-        # If no timezone: explicitly set UTC
+        # If no timezone: use configured timezone
         if registration_end.tzinfo is None:
-            registration_end = registration_end.replace(tzinfo=ZoneInfo("UTC"))
+            registration_end = registration_end.replace(tzinfo=tz)
 
-        now = datetime.now(ZoneInfo("UTC"))
+        now = datetime.now(tz=tz)
         logger.debug(f"registration_end: {registration_end} ({registration_end.tzinfo})")
         logger.debug(f"now: {now} ({now.tzinfo})")
         delay_seconds = max(0, int((registration_end - now).total_seconds()))


### PR DESCRIPTION
**Problem:**
- Negative pause values like "-10170 min" appeared in matchmaker logs
- datetime.fromisoformat() created naive datetime objects without timezone info
- Datetime arithmetic with mixed naive/aware datetimes produced incorrect results

**Root Cause:**
Naive datetime objects (without timezone) were being subtracted from each other or mixed with timezone-aware datetimes, causing incorrect time calculations. This particularly affected pause calculations in the matchmaker where:
  diff = (new_slot - last_match_end).total_seconds() / 60

**Solution:**
Added comprehensive timezone awareness across all modules:

1. **matchmaker.py** (Critical fix):
   - Ensure all datetime.fromisoformat() calls check for timezone
   - Add CONFIG.bot.timezone to all datetime operations
   - Enhanced pause logging with timezone debug info
   - Added timezone info log to slot matrix generation

2. **stats.py**:
   - Fixed tournament status command to use timezone-aware datetimes
   - Prevents incorrect time delta calculations in tournament countdown

3. **poll.py**:
   - Changed from hardcoded UTC to CONFIG.bot.timezone
   - Ensures registration timing calculations are correct

4. **dev_tools.py**:
   - Fixed test_matchmaker command timezone handling
   - Fixed show_state command time remaining calculations

**Key Changes:**
- All fromisoformat() calls now check: if dt.tzinfo is None: dt.replace(tzinfo=tz)
- All datetime.now() calls now use: datetime.now(tz=tz)
- Timezone retrieved from CONFIG.bot.timezone (typically "Europe/Berlin")
- Debug logging shows timezone info when DEBUG_MODE active

**Expected Result:**
Pause calculations should now show positive values reflecting actual time between matches, resolving the negative pause issue.