### PR TITLE
Fix: Update simulate_full_flow to use new timezone & auto-duration fe…

### DIFF
--- a/modules/dev_tools.py
+++ b/modules/dev_tools.py
@@ -344,18 +344,22 @@ class DevGroup(app_commands.Group):
             )
             return
 
-        # Prepare tournament data
-        now = datetime.now()
+        # Prepare tournament data with timezone awareness
+        tz = ZoneInfo(CONFIG.bot.timezone)
+        now = datetime.now(tz=tz)
 
-        # Tournament period: Start now, end after two full weekends starting next Saturday
-        next_saturday = now + timedelta((5 - now.weekday()) % 7)
-        tournament_end = next_saturday + timedelta(days=8)  # Sat + Sun + Sat + Sun
+        # Registration ends in 20 seconds (for quick testing)
+        registration_end = now + timedelta(seconds=20)
+
+        # Tournament duration will be auto-calculated after teams are known
+        # For now, set generous default (will be recalculated automatically)
+        tournament_end = registration_end + timedelta(weeks=12)
 
         tournament_data = {
             "registration_open": False,
             "running": True,
             "solo": [],
-            "registration_end": (now + timedelta(seconds=20)).isoformat(),
+            "registration_end": registration_end.isoformat(),
             "tournament_end": tournament_end.isoformat(),
             "matches": [],
             "poll_results": {},


### PR DESCRIPTION
…atures

**Problem:**
The /dev simulate_full_flow test command used outdated logic:
- datetime.now() without timezone
- Manual tournament duration calculation
- No integration with new auto-duration feature

**Solution:**
Updated to match current production code:
- Use timezone-aware datetime with ZoneInfo(CONFIG.bot.timezone)
- Set default 12-week duration (like real tournament start)
- Let close_registration_after_delay() auto-calculate optimal duration

**Result:**
Test flow now accurately simulates production behavior, including: ✅ Timezone-aware datetime operations
✅ Automatic duration calculation after registration ✅ Consistent with actual tournament startup logic