### PR TITLE
Fix: Prevent duplicate cleanup and schedule output (race condition)

### DIFF
--- a/modules/admin_tools.py
+++ b/modules/admin_tools.py
@@ -124,6 +124,13 @@ async def handle_start_tournament_modal(
         await interaction.followup.send("🚫 No permission.", ephemeral=True)
         return
 
+    # Reset registration closed flag for new tournament
+    from modules.tournament import _registration_lock
+    import modules.tournament as tournament_module
+    async with _registration_lock:
+        tournament_module._registration_closed = False
+        logger.debug("[TOURNAMENT] Registration flag reset for new tournament")
+
     try:
         tournament = load_tournament_data()
         if tournament.get("running", False):


### PR DESCRIPTION
**Problem:**
Cleanup message and schedule were displayed twice because close_registration_after_delay() was called twice:
1. Manually in simulate_full_flow (line 404)
2. Automatically by auto_end_poll via poll.py

Both calls executed simultaneously, causing:
- "Aufräumen abgeschlossen" message twice
- "Spielplan Übersicht" output twice
- Potential data inconsistencies

**Root Causes:**
1. Redundant manual call in simulate_full_flow
2. Race condition: _registration_closed flag check wasn't atomic

**Solutions:**

1. **Removed redundant call (dev_tools.py):**
   - Removed manual close_registration_after_delay() call
   - auto_end_poll automatically triggers it via poll.py
   - Added clarifying comment

2. **Made flag check atomic (tournament.py):**
   - Added asyncio.Lock: _registration_lock
   - Wrapped flag check+set in "async with _registration_lock"
   - Prevents race conditions if multiple calls still happen

3. **Reset flag for new tournaments:**
   - Reset _registration_closed in handle_start_tournament_modal
   - Reset in simulate_full_flow before test
   - Ensures clean state for each tournament

**Result:**
✅ Only one cleanup message per tournament
✅ Only one schedule output
✅ Thread-safe double-call prevention
✅ Clean state for each new tournament