### PR TITLE
Refactor: Simplify archiving - remove redundant backup function

### DIFF
--- a/modules/archive.py
+++ b/modules/archive.py
@@ -16,6 +16,10 @@ from modules.logger import logger
 def archive_current_tournament():
     """
     Archives the current tournament data to a timestamped JSON file.
+    Only archives tournament-specific data (matches, teams, player_stats).
+
+    Note: games.json is NOT archived as it rarely changes and is not tournament-specific.
+
     Returns the path to the archive file.
     """
     tournament = load_tournament_data()
@@ -25,10 +29,13 @@ def archive_current_tournament():
     if not os.path.exists(archive_folder):
         os.makedirs(archive_folder)
 
+    # Only archive tournament-relevant data from global_data
+    # Exclude "games" as they're not tournament-specific and rarely change
     archive_data = {
         "archived_on": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
         "tournament": tournament,
-        "global_data": global_data,
+        "player_stats": global_data.get("player_stats", {}),
+        "last_tournament_winner": global_data.get("last_tournament_winner", {}),
     }
 
     timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
@@ -37,6 +44,7 @@ def archive_current_tournament():
     with open(filename, "w", encoding="utf-8") as f:
         json.dump(archive_data, f, indent=4, ensure_ascii=False)
 
+    logger.info(f"[ARCHIVE] Tournament archived to: {filename}")
     return filename
 
 

--- a/modules/dataStorage.py
+++ b/modules/dataStorage.py
@@ -413,38 +413,6 @@ def remove_game(game_id: str) -> None:
     logger.info(f"[GAME] Game '{game_id}' was deleted.")
 
 
-def backup_current_state() -> None:
-    """
-    Creates backups of tournament, global data, and games from /data/.
-    Saves them in /backups/ with timestamp.
-    """
-    backup_folder = os.path.join(BASE_DIR, "backups")
-    if not os.path.exists(backup_folder):
-        os.makedirs(backup_folder)
-
-    now = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-
-    files_to_backup = {
-        TOURNAMENT_FILE_PATH: f"tournament_backup_{now}.json",
-        DATA_FILE_PATH: f"data_backup_{now}.json",
-        GAMES_FILE_PATH: f"games_backup_{now}.json",
-    }
-
-    backed_up = 0
-    for source_file, backup_name in files_to_backup.items():
-        if os.path.exists(source_file):
-            try:
-                shutil.copy(source_file, os.path.join(backup_folder, backup_name))
-                logger.info(f"[BACKUP] Backed up: {os.path.basename(source_file)}")
-                backed_up += 1
-            except IOError as e:
-                logger.error(f"[BACKUP] Failed to backup {os.path.basename(source_file)}: {e}")
-        else:
-            logger.debug(f"[BACKUP] File not found, skipping: {os.path.basename(source_file)}")
-
-    logger.info(f"[BACKUP] Backup completed: {backed_up}/{len(files_to_backup)} files backed up")
-
-
 def delete_tournament_file() -> None:
     """
     Delete tournament.json file.

--- a/modules/tournament.py
+++ b/modules/tournament.py
@@ -14,7 +14,6 @@ from modules import poll
 from modules.archive import archive_current_tournament, update_tournament_history
 from modules.config import CONFIG
 from modules.dataStorage import (
-    backup_current_state,
     delete_tournament_file,
     load_games,
     load_global_data,
@@ -85,15 +84,12 @@ async def end_tournament_procedure(
         await channel.send("⚠️ Not all matches are completed yet. Tournament remains open.")
         return
 
-    # Archive and cleanup
+    # Archive tournament data
     try:
         archive_path = archive_current_tournament()
-        logger.info(f"[TOURNAMENT] Tournament archived at: {archive_path}")
+        logger.info(f"[TOURNAMENT] Tournament successfully archived to: {archive_path}")
     except Exception as e:
-        logger.error(f"[TOURNAMENT] Error archiving: {e}")
-
-    backup_current_state()
-    logger.info(f"[TOURNAMENT] Backup successful")
+        logger.error(f"[TOURNAMENT] Error archiving tournament: {e}")
 
     # Winners, MVP, etc.
     winner_ids = get_winner_ids()


### PR DESCRIPTION
Applies KISS principle by consolidating to single archive function.

Changes in archive.py:
- Only archive tournament-specific data (player_stats, last_tournament_winner)
- Exclude games list (not tournament-specific, rarely changes)
- Add explicit logging for archive path

Changes in dataStorage.py:
- Remove backup_current_state() function (redundant with archive)
- Eliminate duplicate backup of games.json

Changes in tournament.py:
- Remove backup_current_state() import and call
- Keep only archive_current_tournament() for end-of-tournament backup
- Simplify end_tournament_procedure()

Benefits:
- Less code duplication (KISS)
- No unnecessary games.json backup on every tournament
- Single source of truth for archiving
- Cleaner codebase