### PR TITLE
Feature: Implement forfeit system for team withdrawals

### DIFF
--- a/modules/matchmaker.py
+++ b/modules/matchmaker.py
@@ -425,16 +425,22 @@ def generate_schedule_overview(matches: list) -> str:
             match_status = match.get("status", "open")
 
             # Determine emoji
-            if match.get("rescue_assigned"):
+            if match_status == "forfeit":
+                emoji = "⚠️"  # Forfeit match
+                winner = match.get("winner", "Unknown")
+                description += f"{emoji} {dt.strftime('%H:%M')} – **{team1}** vs **{team2}** (Forfeit → {winner} wins)\n"
+            elif match.get("rescue_assigned"):
                 emoji = "❗"
+                description += f"{emoji} {dt.strftime('%H:%M')} – **{team1}** vs **{team2}**\n"
             elif match_status == "completed":
                 emoji = "✅"
+                description += f"{emoji} {dt.strftime('%H:%M')} – **{team1}** vs **{team2}**\n"
             elif dt.date() == today:
                 emoji = "🔥"
+                description += f"{emoji} {dt.strftime('%H:%M')} – **{team1}** vs **{team2}**\n"
             else:
                 emoji = "🕒"
-
-            description += f"{emoji} {dt.strftime('%H:%M')} – **{team1}** vs **{team2}**\n"
+                description += f"{emoji} {dt.strftime('%H:%M')} – **{team1}** vs **{team2}**\n"
 
         description += "\n"
 

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -516,11 +516,14 @@ async def games_autocomplete(interaction: discord.Interaction, current: str):
 
 
 def all_matches_completed() -> bool:
-    """Check if all matches are completed."""
+    """
+    Check if all matches are completed or forfeited.
+    Forfeit matches count as completed since they have a determined outcome.
+    """
     tournament = load_tournament_data()
     matches = tournament.get("matches", [])
 
-    return all(match.get("status") == "completed" for match in matches)
+    return all(match.get("status") in ("completed", "forfeit") for match in matches)
 
 
 def get_current_chosen_game() -> str:


### PR DESCRIPTION
Handles edge case when player leaves tournament after registration closes.

Changes in players.py (player leave command):
DURING registration:
- Existing behavior: Dissolve team, move partner to solo queue

AFTER registration close (NEW):
- Mark team as "withdrawn" (keep in system for match integrity)
- Set all team matches to "forfeit" status
- Award automatic wins to opponents
- Notify remaining partner in channel
- Log withdrawal with timestamp and reason

Changes in utils.py:
- Update all_matches_completed() to treat forfeit as completed
- Forfeit matches have determined outcome (opponent wins)

Changes in matchmaker.py:
- Update generate_schedule_overview() to display forfeit matches
- Show ⚠️ emoji for forfeit matches
- Display winner: "(Forfeit → TeamX wins)"

Benefits:
- Prevents "ghost teams" in match schedule
- Maintains tournament integrity (no broken references)
- Fair outcome for opponents (automatic wins)
- Partner gets notified about withdrawal
- Clean audit trail (withdrawal timestamp, reason)

Edge case example:
Before: Team deleted → matches point to non-existent team → crash After: Team marked withdrawn → matches forfeited → opponents win