### PR TITLE
Refactor: Move setup embed to locale files for i18n

### DIFF
--- a/locale/de/embeds/setup.json
+++ b/locale/de/embeds/setup.json
@@ -1,0 +1,8 @@
+{
+  "SETUP_WELCOME": {
+    "title": "🎮 Willkommen zum HeroldBot Setup!",
+    "description": "Dieser Assistent hilft dir, den Bot für deinen Server zu konfigurieren.\n\n**Du wirst konfigurieren:**\n📍 Limits Channel\n📍 Reminder Channel\n📍 Reschedule Channel\n🏆 Champion/Sieger Rolle\n🕒 Zeitzone\n\nKlicke auf **Setup starten** um zu beginnen.",
+    "footer": "Du kannst dieses Setup jederzeit mit /setup start erneut ausführen",
+    "color": "0x5865F2"
+  }
+}

--- a/locale/en/embeds/setup.json
+++ b/locale/en/embeds/setup.json
@@ -1,0 +1,8 @@
+{
+  "SETUP_WELCOME": {
+    "title": "🎮 Welcome to HeroldBot Setup!",
+    "description": "This wizard will help you configure the bot for your server.\n\n**You will configure:**\n📍 Limits Channel\n📍 Reminder Channel\n📍 Reschedule Channel\n🏆 Champion/Winner Role\n🕒 Timezone\n\nClick **Start Setup** below to begin.",
+    "footer": "You can run this setup again anytime with /setup start",
+    "color": "0x5865F2"
+  }
+}

--- a/modules/setup.py
+++ b/modules/setup.py
@@ -11,6 +11,7 @@ from discord.ui import Modal, TextInput, View, Button
 
 from modules.logger import logger
 from modules.utils import has_permission
+from modules.embeds import build_embed_from_template, load_embed_template
 
 
 class SetupModal(Modal, title="🎮 HeroldBot Setup"):
@@ -237,21 +238,19 @@ class SetupCommands(app_commands.Group):
             )
             return
 
-        embed = discord.Embed(
-            title="🎮 Welcome to HeroldBot Setup!",
-            description=(
-                "This wizard will help you configure the bot for your server.\n\n"
-                "**You will configure:**\n"
-                "📍 Limits Channel\n"
-                "📍 Reminder Channel\n"
-                "📍 Reschedule Channel\n"
-                "🏆 Champion/Winner Role\n"
-                "🕒 Timezone\n\n"
-                "Click **Start Setup** below to begin."
-            ),
-            color=0x5865F2
-        )
-        embed.set_footer(text="You can run this setup again anytime with /setup start")
+        # Load embed from locale file
+        try:
+            templates = load_embed_template("setup")
+            template = templates.get("SETUP_WELCOME")
+            embed = build_embed_from_template(template, {})
+        except Exception as e:
+            logger.error(f"[SETUP] Error loading setup embed: {e}")
+            # Fallback embed if template loading fails
+            embed = discord.Embed(
+                title="🎮 HeroldBot Setup",
+                description="Click the button below to start the setup wizard.",
+                color=0x5865F2
+            )
 
         view = SetupView()
         await interaction.response.send_message(embed=embed, view=view, ephemeral=False)


### PR DESCRIPTION
Makes setup wizard consistent with existing embed system.

Changes:
- Created locale/de/embeds/setup.json (German)
- Created locale/en/embeds/setup.json (English)
- Updated modules/setup.py to use build_embed_from_template()
- Removed hardcoded embed in setup_start()
- Added fallback embed if template loading fails

Benefits:
- Consistent with existing embed system
- Easy to translate to other languages
- Central location for all UI text
- Follows established patterns

Structure:
locale/
├── de/embeds/setup.json
└── en/embeds/setup.json

Both contain SETUP_WELCOME template with:
- title
- description
- footer
- color