### PR TITLE
Refactor: Consolidate structure - KISS principle

### DIFF
--- a/modules/admin_tools.py
+++ b/modules/admin_tools.py
@@ -41,7 +41,7 @@ from modules.modals import (
 )
 
 from modules.poll import end_poll
-from modules.shared_states import pending_reschedules
+from modules.reschedule import pending_reschedules
 from modules.tournament import end_tournament_procedure, auto_end_poll
 from modules.utils import (
     autocomplete_teams,

--- a/modules/reschedule.py
+++ b/modules/reschedule.py
@@ -22,9 +22,11 @@ from modules.embeds import (
 )
 from modules.logger import logger
 from modules.matchmaker import generate_slot_matrix, get_valid_slots_for_match, assign_slots_with_matrix
-from modules.shared_states import pending_reschedules
 from modules.utils import get_player_team, get_team_open_matches, smart_send
-from views.reschedule_view import RescheduleView, SlotSelectView
+from modules.reschedule_view import RescheduleView, SlotSelectView
+
+# Global state for pending reschedule requests
+pending_reschedules = set()
 
 RESCHEDULE_TIMEOUT_HOURS = CONFIG.tournament.reschedule_timeout_hours
 

--- a/modules/reschedule_view.py
+++ b/modules/reschedule_view.py
@@ -8,7 +8,6 @@ from zoneinfo import ZoneInfo
 
 # Lokale Module
 from modules.dataStorage import load_tournament_data, save_tournament_data
-from modules.shared_states import pending_reschedules
 from modules.logger import logger
 
 
@@ -145,6 +144,8 @@ class RescheduleView(ui.View):
             save_tournament_data(tournament)
             logger.info(f"[RESCHEDULE] Match {self.match_id} forfeited by {decliner_team}. Winner: {opponent}")
 
+        # Import at runtime to avoid circular dependency
+        from modules.reschedule import pending_reschedules
         pending_reschedules.discard(self.match_id)
 
         if self.message:
@@ -172,6 +173,8 @@ class RescheduleView(ui.View):
             save_tournament_data(tournament)
             logger.info(f"[RESCHEDULE] Match {self.match_id} successfully rescheduled to {self.new_datetime}.")
 
+        # Import at runtime to avoid circular dependency
+        from modules.reschedule import pending_reschedules
         pending_reschedules.discard(self.match_id)
 
         await self.message.edit(
@@ -190,4 +193,6 @@ class RescheduleView(ui.View):
                 embed=None,
                 view=None
             )
+        # Import at runtime to avoid circular dependency
+        from modules.reschedule import pending_reschedules
         pending_reschedules.discard(self.match_id)

--- a/modules/shared_states.py
+++ b/modules/shared_states.py
@@ -1,4 +1,0 @@
-# modules/shared_states.py
-
-# Set of pending reschedule requests
-pending_reschedules = set()


### PR DESCRIPTION
Simplifies project structure by consolidating all modules into modules/ directory.

Changes:
1. Moved views/reschedule_view.py → modules/reschedule_view.py
2. Moved pending_reschedules from shared_states.py into reschedule.py
3. Deleted modules/shared_states.py (no longer needed)
4. Deleted views/ directory (empty)

Updated imports:
- modules/reschedule.py:
  * Import reschedule_view from modules instead of views
  * Define pending_reschedules directly (no import)

- modules/reschedule_view.py:
  * Runtime import of pending_reschedules to avoid circular dependency
  * Import from modules.reschedule at usage points

- modules/admin_tools.py:
  * Import pending_reschedules from modules.reschedule

Benefits:
- KISS: Everything in one place (modules/)
- No separate views/ or shared_states.py needed
- Simpler directory structure
- Easier to find files
- Consistent with existing module organization

Structure before:
modules/
  reschedule.py shared_states.py (global state) views/
  reschedule_view.py (UI components)

Structure after:
modules/
  reschedule.py (logic + global state) reschedule_view.py (UI components)