### PR TITLE
Feature: Add /info help and move embeds to locale templates

### DIFF
--- a/locale/de/embeds/info.json
+++ b/locale/de/embeds/info.json
@@ -1,0 +1,94 @@
+{
+  "HELP": {
+    "title": "📖 HeroldBot - Hilfe & Anleitung",
+    "description": "Willkommen zum automatisierten Turniersystem! Hier findest du alle wichtigen Informationen.",
+    "color": "0x5865F2",
+    "fields": [
+      {
+        "name": "🎮 Turnier-Ablauf",
+        "value": "1️⃣ **Spiele-Abstimmung** - Wähle dein Lieblingsspiel\n2️⃣ **Anmeldung** - Registriere dich solo oder als Team\n3️⃣ **Matchmaking** - Automatische Terminplanung\n4️⃣ **Matches spielen** - Spiele nach Zeitplan\n5️⃣ **Siegerehrung** - Die besten Teams gewinnen!",
+        "inline": false
+      },
+      {
+        "name": "📝 Wichtige Befehle",
+        "value": "`/player join` - Für Turnier anmelden\n`/player leave` - Vom Turnier abmelden\n`/player request_reschedule` - Match verschieben\n`/info participants` - Teilnehmerliste\n`/info tournament` - Turnierstatus\n`/info stats` - Deine Statistiken",
+        "inline": false
+      },
+      {
+        "name": "⏰ Zeitplanung",
+        "value": "Bei der Anmeldung gibst du deine Verfügbarkeit an (Samstag/Sonntag + Zeiten). Der Bot plant Matches automatisch in deinen verfügbaren Zeiten.",
+        "inline": false
+      },
+      {
+        "name": "🔄 Match verschieben",
+        "value": "Du kannst bis zu 24h vor dem Match eine Verschiebung anfragen. Beide Teams müssen zustimmen. Lehnt ein Team ab = Forfeit!",
+        "inline": false
+      },
+      {
+        "name": "🏆 Punkte & Sieg",
+        "value": "Jedes gewonnene Match zählt als Sieg. Am Ende gewinnt das Team mit den meisten Siegen!",
+        "inline": false
+      }
+    ],
+    "footer": "Viel Erfolg im Turnier! 🎉"
+  },
+  "PLAYER_STATS": {
+    "title": "📊 Statistiken für {player_name}",
+    "color": "0x3498DB",
+    "fields": [
+      {
+        "name": "🏆 Siege",
+        "value": "{wins}",
+        "inline": true
+      },
+      {
+        "name": "🧩 Teilnahmen",
+        "value": "{participations}",
+        "inline": true
+      },
+      {
+        "name": "📈 Siegesquote",
+        "value": "{winrate}",
+        "inline": true
+      },
+      {
+        "name": "🎮 Lieblingsspiel",
+        "value": "{favorite_game}",
+        "inline": false
+      }
+    ],
+    "footer": "Turnierauswertung"
+  },
+  "TEAM_STATS": {
+    "title": "📊 Team-Statistiken: {team_name}",
+    "color": "0x1ABC9C",
+    "fields": [
+      {
+        "name": "🏆 Siege",
+        "value": "{wins}",
+        "inline": true
+      },
+      {
+        "name": "🎯 Gespielte Matches",
+        "value": "{matches_played}",
+        "inline": true
+      }
+    ],
+    "footer": "Turnierauswertung"
+  },
+  "LEADERBOARD": {
+    "title": "🏆 Bestenliste",
+    "description": "{leaderboard}",
+    "color": "0xF1C40F"
+  },
+  "MATCH_HISTORY": {
+    "title": "🏛️ Turnier Match-Historie",
+    "description": "Hier sind die vergangenen Matches:",
+    "color": "0x7289DA"
+  },
+  "PARTICIPANTS": {
+    "title": "👥 Turnier Teilnehmer",
+    "color": "0x3498DB",
+    "fields": []
+  }
+}

--- a/locale/en/embeds/info.json
+++ b/locale/en/embeds/info.json
@@ -1,0 +1,94 @@
+{
+  "HELP": {
+    "title": "📖 HeroldBot - Help & Guide",
+    "description": "Welcome to the automated tournament system! Here you'll find all important information.",
+    "color": "0x5865F2",
+    "fields": [
+      {
+        "name": "🎮 Tournament Flow",
+        "value": "1️⃣ **Game Poll** - Vote for your favorite game\n2️⃣ **Registration** - Register solo or as a team\n3️⃣ **Matchmaking** - Automatic scheduling\n4️⃣ **Play Matches** - Play according to schedule\n5️⃣ **Awards** - Best teams win!",
+        "inline": false
+      },
+      {
+        "name": "📝 Important Commands",
+        "value": "`/player join` - Register for tournament\n`/player leave` - Unregister from tournament\n`/player request_reschedule` - Reschedule match\n`/info participants` - Participant list\n`/info tournament` - Tournament status\n`/info stats` - Your statistics",
+        "inline": false
+      },
+      {
+        "name": "⏰ Scheduling",
+        "value": "During registration you provide your availability (Saturday/Sunday + times). The bot automatically schedules matches during your available times.",
+        "inline": false
+      },
+      {
+        "name": "🔄 Rescheduling",
+        "value": "You can request a reschedule up to 24h before the match. Both teams must agree. If a team declines = Forfeit!",
+        "inline": false
+      },
+      {
+        "name": "🏆 Points & Victory",
+        "value": "Each won match counts as a victory. The team with most victories wins!",
+        "inline": false
+      }
+    ],
+    "footer": "Good luck in the tournament! 🎉"
+  },
+  "PLAYER_STATS": {
+    "title": "📊 Statistics for {player_name}",
+    "color": "0x3498DB",
+    "fields": [
+      {
+        "name": "🏆 Wins",
+        "value": "{wins}",
+        "inline": true
+      },
+      {
+        "name": "🧩 Participations",
+        "value": "{participations}",
+        "inline": true
+      },
+      {
+        "name": "📈 Win Rate",
+        "value": "{winrate}",
+        "inline": true
+      },
+      {
+        "name": "🎮 Favorite Game",
+        "value": "{favorite_game}",
+        "inline": false
+      }
+    ],
+    "footer": "Tournament Evaluation"
+  },
+  "TEAM_STATS": {
+    "title": "📊 Team Statistics: {team_name}",
+    "color": "0x1ABC9C",
+    "fields": [
+      {
+        "name": "🏆 Wins",
+        "value": "{wins}",
+        "inline": true
+      },
+      {
+        "name": "🎯 Matches Played",
+        "value": "{matches_played}",
+        "inline": true
+      }
+    ],
+    "footer": "Tournament Evaluation"
+  },
+  "LEADERBOARD": {
+    "title": "🏆 Leaderboard",
+    "description": "{leaderboard}",
+    "color": "0xF1C40F"
+  },
+  "MATCH_HISTORY": {
+    "title": "🏛️ Tournament Match History",
+    "description": "Here are the past matches:",
+    "color": "0x7289DA"
+  },
+  "PARTICIPANTS": {
+    "title": "👥 Tournament Participants",
+    "color": "0x3498DB",
+    "fields": []
+  }
+}


### PR DESCRIPTION
Changes:
- Created locale/de/embeds/info.json with German templates
- Created locale/en/embeds/info.json with English templates
- Refactored all hardcoded embeds in info.py to use locale templates:
  * PLAYER_STATS - Player statistics embed
  * TEAM_STATS - Team statistics embed
  * LEADERBOARD - Leaderboard display
  * MATCH_HISTORY - Match history display
  * PARTICIPANTS - Participants list
  * HELP - New help guide (NEW)
- Added new /info help command with comprehensive player guide
- All embeds now support i18n and can be easily customized

Benefits:
- Consistent embed styling across all info commands
- Easy localization and customization via JSON
- New help command provides onboarding for players
- Follows existing locale template pattern