### PR TITLE
Fix: Correct placeholder format in info.json templates

### DIFF
--- a/locale/de/embeds/info.json
+++ b/locale/de/embeds/info.json
@@ -6,79 +6,68 @@
     "fields": [
       {
         "name": "🎮 Turnier-Ablauf",
-        "value": "1️⃣ **Spiele-Abstimmung** - Wähle dein Lieblingsspiel\n2️⃣ **Anmeldung** - Registriere dich solo oder als Team\n3️⃣ **Matchmaking** - Automatische Terminplanung\n4️⃣ **Matches spielen** - Spiele nach Zeitplan\n5️⃣ **Siegerehrung** - Die besten Teams gewinnen!",
-        "inline": false
+        "value": "1️⃣ **Spiele-Abstimmung** - Wähle dein Lieblingsspiel\n2️⃣ **Anmeldung** - Registriere dich solo oder als Team\n3️⃣ **Matchmaking** - Automatische Terminplanung\n4️⃣ **Matches spielen** - Spiele nach Zeitplan\n5️⃣ **Siegerehrung** - Die besten Teams gewinnen!"
       },
       {
         "name": "📝 Wichtige Befehle",
-        "value": "`/player join` - Für Turnier anmelden\n`/player leave` - Vom Turnier abmelden\n`/player request_reschedule` - Match verschieben\n`/info participants` - Teilnehmerliste\n`/info tournament` - Turnierstatus\n`/info stats` - Deine Statistiken",
-        "inline": false
+        "value": "`/player join` - Für Turnier anmelden\n`/player leave` - Vom Turnier abmelden\n`/player request_reschedule` - Match verschieben\n`/info participants` - Teilnehmerliste\n`/info tournament` - Turnierstatus\n`/info stats` - Deine Statistiken"
       },
       {
         "name": "⏰ Zeitplanung",
-        "value": "Bei der Anmeldung gibst du deine Verfügbarkeit an (Samstag/Sonntag + Zeiten). Der Bot plant Matches automatisch in deinen verfügbaren Zeiten.",
-        "inline": false
+        "value": "Bei der Anmeldung gibst du deine Verfügbarkeit an (Samstag/Sonntag + Zeiten). Der Bot plant Matches automatisch in deinen verfügbaren Zeiten."
       },
       {
         "name": "🔄 Match verschieben",
-        "value": "Du kannst bis zu 24h vor dem Match eine Verschiebung anfragen. Beide Teams müssen zustimmen. Lehnt ein Team ab = Forfeit!",
-        "inline": false
+        "value": "Du kannst bis zu 24h vor dem Match eine Verschiebung anfragen. Beide Teams müssen zustimmen. Lehnt ein Team ab = Forfeit!"
       },
       {
         "name": "🏆 Punkte & Sieg",
-        "value": "Jedes gewonnene Match zählt als Sieg. Am Ende gewinnt das Team mit den meisten Siegen!",
-        "inline": false
+        "value": "Jedes gewonnene Match zählt als Sieg. Am Ende gewinnt das Team mit den meisten Siegen!"
       }
     ],
     "footer": "Viel Erfolg im Turnier! 🎉"
   },
   "PLAYER_STATS": {
-    "title": "📊 Statistiken für {player_name}",
+    "title": "📊 Statistiken für PLACEHOLDER_PLAYER_NAME",
     "color": "0x3498DB",
     "fields": [
       {
         "name": "🏆 Siege",
-        "value": "{wins}",
-        "inline": true
+        "value": "PLACEHOLDER_WINS"
       },
       {
         "name": "🧩 Teilnahmen",
-        "value": "{participations}",
-        "inline": true
+        "value": "PLACEHOLDER_PARTICIPATIONS"
       },
       {
         "name": "📈 Siegesquote",
-        "value": "{winrate}",
-        "inline": true
+        "value": "PLACEHOLDER_WINRATE"
       },
       {
         "name": "🎮 Lieblingsspiel",
-        "value": "{favorite_game}",
-        "inline": false
+        "value": "PLACEHOLDER_FAVORITE_GAME"
       }
     ],
     "footer": "Turnierauswertung"
   },
   "TEAM_STATS": {
-    "title": "📊 Team-Statistiken: {team_name}",
+    "title": "📊 Team-Statistiken: PLACEHOLDER_TEAM_NAME",
     "color": "0x1ABC9C",
     "fields": [
       {
         "name": "🏆 Siege",
-        "value": "{wins}",
-        "inline": true
+        "value": "PLACEHOLDER_WINS"
       },
       {
         "name": "🎯 Gespielte Matches",
-        "value": "{matches_played}",
-        "inline": true
+        "value": "PLACEHOLDER_MATCHES_PLAYED"
       }
     ],
     "footer": "Turnierauswertung"
   },
   "LEADERBOARD": {
     "title": "🏆 Bestenliste",
-    "description": "{leaderboard}",
+    "description": "PLACEHOLDER_LEADERBOARD",
     "color": "0xF1C40F"
   },
   "MATCH_HISTORY": {
@@ -88,7 +77,6 @@
   },
   "PARTICIPANTS": {
     "title": "👥 Turnier Teilnehmer",
-    "color": "0x3498DB",
-    "fields": []
+    "color": "0x3498DB"
   }
 }

--- a/locale/en/embeds/info.json
+++ b/locale/en/embeds/info.json
@@ -6,79 +6,68 @@
     "fields": [
       {
         "name": "🎮 Tournament Flow",
-        "value": "1️⃣ **Game Poll** - Vote for your favorite game\n2️⃣ **Registration** - Register solo or as a team\n3️⃣ **Matchmaking** - Automatic scheduling\n4️⃣ **Play Matches** - Play according to schedule\n5️⃣ **Awards** - Best teams win!",
-        "inline": false
+        "value": "1️⃣ **Game Poll** - Vote for your favorite game\n2️⃣ **Registration** - Register solo or as a team\n3️⃣ **Matchmaking** - Automatic scheduling\n4️⃣ **Play Matches** - Play according to schedule\n5️⃣ **Awards** - Best teams win!"
       },
       {
         "name": "📝 Important Commands",
-        "value": "`/player join` - Register for tournament\n`/player leave` - Unregister from tournament\n`/player request_reschedule` - Reschedule match\n`/info participants` - Participant list\n`/info tournament` - Tournament status\n`/info stats` - Your statistics",
-        "inline": false
+        "value": "`/player join` - Register for tournament\n`/player leave` - Unregister from tournament\n`/player request_reschedule` - Reschedule match\n`/info participants` - Participant list\n`/info tournament` - Tournament status\n`/info stats` - Your statistics"
       },
       {
         "name": "⏰ Scheduling",
-        "value": "During registration you provide your availability (Saturday/Sunday + times). The bot automatically schedules matches during your available times.",
-        "inline": false
+        "value": "During registration you provide your availability (Saturday/Sunday + times). The bot automatically schedules matches during your available times."
       },
       {
         "name": "🔄 Rescheduling",
-        "value": "You can request a reschedule up to 24h before the match. Both teams must agree. If a team declines = Forfeit!",
-        "inline": false
+        "value": "You can request a reschedule up to 24h before the match. Both teams must agree. If a team declines = Forfeit!"
       },
       {
         "name": "🏆 Points & Victory",
-        "value": "Each won match counts as a victory. The team with most victories wins!",
-        "inline": false
+        "value": "Each won match counts as a victory. The team with most victories wins!"
       }
     ],
     "footer": "Good luck in the tournament! 🎉"
   },
   "PLAYER_STATS": {
-    "title": "📊 Statistics for {player_name}",
+    "title": "📊 Statistics for PLACEHOLDER_PLAYER_NAME",
     "color": "0x3498DB",
     "fields": [
       {
         "name": "🏆 Wins",
-        "value": "{wins}",
-        "inline": true
+        "value": "PLACEHOLDER_WINS"
       },
       {
         "name": "🧩 Participations",
-        "value": "{participations}",
-        "inline": true
+        "value": "PLACEHOLDER_PARTICIPATIONS"
       },
       {
         "name": "📈 Win Rate",
-        "value": "{winrate}",
-        "inline": true
+        "value": "PLACEHOLDER_WINRATE"
       },
       {
         "name": "🎮 Favorite Game",
-        "value": "{favorite_game}",
-        "inline": false
+        "value": "PLACEHOLDER_FAVORITE_GAME"
       }
     ],
     "footer": "Tournament Evaluation"
   },
   "TEAM_STATS": {
-    "title": "📊 Team Statistics: {team_name}",
+    "title": "📊 Team Statistics: PLACEHOLDER_TEAM_NAME",
     "color": "0x1ABC9C",
     "fields": [
       {
         "name": "🏆 Wins",
-        "value": "{wins}",
-        "inline": true
+        "value": "PLACEHOLDER_WINS"
       },
       {
         "name": "🎯 Matches Played",
-        "value": "{matches_played}",
-        "inline": true
+        "value": "PLACEHOLDER_MATCHES_PLAYED"
       }
     ],
     "footer": "Tournament Evaluation"
   },
   "LEADERBOARD": {
     "title": "🏆 Leaderboard",
-    "description": "{leaderboard}",
+    "description": "PLACEHOLDER_LEADERBOARD",
     "color": "0xF1C40F"
   },
   "MATCH_HISTORY": {
@@ -88,7 +77,6 @@
   },
   "PARTICIPANTS": {
     "title": "👥 Tournament Participants",
-    "color": "0x3498DB",
-    "fields": []
+    "color": "0x3498DB"
   }
 }

--- a/modules/info.py
+++ b/modules/info.py
@@ -57,6 +57,7 @@ def build_stats_embed(user, stats: dict) -> Embed:
     if game_stats:
         favorite_game = max(game_stats.items(), key=lambda x: x[1])[0]
 
+    # Note: Keys are lowercase, build_embed_from_template converts them to PLACEHOLDER_{KEY.upper()}
     placeholders = {
         "player_name": user.display_name,
         "wins": str(wins),


### PR DESCRIPTION
Changed from {key} format to PLACEHOLDER_{KEY} format to match the existing build_embed_from_template() function which uses PLACEHOLDER_{key.upper()} replacement pattern.

This ensures language selection works correctly with the locale system.