### PR TITLE
Fix: Remove obsolete features and import errors

### DIFF
--- a/modules/config.py
+++ b/modules/config.py
@@ -102,8 +102,6 @@ class TournamentConfig:
 class Features:
     """Feature flags."""
     reminder_enabled: bool
-    auto_move: bool
-    create_event: bool
     game_key_handler: bool
     debug_save_slot_matrix: bool
 

--- a/modules/matchmaker.py
+++ b/modules/matchmaker.py
@@ -15,7 +15,7 @@ from discord import TextChannel
 # Local modules
 from modules.config import CONFIG
 from modules.dataStorage import DEBUG_MODE, load_tournament_data, save_tournament_data
-from modules.embeds import send_cleanup_summary
+# Removed: send_cleanup_summary import - function deleted to reduce spam
 from modules.logger import logger
 from modules.utils import generate_team_name, get_active_days_config
 


### PR DESCRIPTION
1. Removed auto_move and create_event from Features dataclass
   - These features were already removed from features.json
   - Caused startup error: missing required positional arguments

2. Removed send_cleanup_summary import from matchmaker.py
   - Function was deleted in spam reduction refactoring
   - Caused ImportError on startup

Both errors prevented bot from starting.