### PR TITLE
Fix: Improve tournament leave edge case handling

### DIFF
--- a/modules/matchmaker.py
+++ b/modules/matchmaker.py
@@ -431,7 +431,10 @@ def generate_schedule_overview(matches: list) -> str:
             if match_status == "forfeit":
                 emoji = "⚠️"  # Forfeit match
                 winner = match.get("winner", "Unknown")
-                description += f"{emoji} {dt.strftime('%H:%M')} – **{team1}** vs **{team2}** (Forfeit → {winner} wins)\n"
+                if "both teams withdrawn" in str(winner).lower():
+                    description += f"{emoji} {dt.strftime('%H:%M')} – **{team1}** vs **{team2}** (Forfeit → No winner)\n"
+                else:
+                    description += f"{emoji} {dt.strftime('%H:%M')} – **{team1}** vs **{team2}** (Forfeit → {winner} wins)\n"
             elif match.get("rescue_assigned"):
                 emoji = "❗"
                 description += f"{emoji} {dt.strftime('%H:%M')} – **{team1}** vs **{team2}**\n"


### PR DESCRIPTION
When a player leaves after matches are distributed:
- Only forfeit OPEN matches (preserve completed/already forfeited)
- Check if opponent team is also withdrawn
- Handle display when both teams are withdrawn
- Add proper forfeit tracking with forfeit_by field

This prevents overwriting completed match results and handles the edge case where both teams withdraw from a match.