### PR TITLE
Add: Availability conflict resolution system

### DIFF
--- a/modules/availability_conflict_resolver.py
+++ b/modules/availability_conflict_resolver.py
@@ -1,0 +1,443 @@
+"""
+Availability Conflict Resolver
+
+Detects and resolves availability conflicts between teams.
+"""
+
+from typing import List, Dict, Set, Tuple, Optional
+from datetime import datetime
+from zoneinfo import ZoneInfo
+import discord
+
+from modules.dataStorage import load_tournament_data, save_tournament_data
+from modules.logger import logger
+from modules.config import CONFIG
+from modules.matchmaker import (
+    AvailabilityChecker,
+    get_valid_slots_for_match,
+    generate_slot_matrix
+)
+from modules.availability_conflict_view import (
+    AvailabilityConflictView,
+    generate_availability_suggestions
+)
+
+
+class ConflictResolutionCoordinator:
+    """
+    Coordinates the resolution of availability conflicts.
+    Manages the workflow from detection to resolution.
+    """
+
+    def __init__(self, channel: discord.TextChannel):
+        self.channel = channel
+        self.pending_resolutions: Set[int] = set()
+        self.excluded_teams: Set[str] = set()
+        self.resolved_matches: Dict[int, datetime] = {}
+
+    async def detect_and_resolve_conflicts(self) -> bool:
+        """
+        Detect matches with no overlapping availability and initiate resolution.
+
+        :return: True if conflicts were found and resolution started, False otherwise
+        """
+        tournament = load_tournament_data()
+        matches = tournament.get("matches", [])
+        teams = tournament.get("teams", {})
+
+        # Find unassigned matches
+        unassigned_matches = [m for m in matches if not m.get("scheduled_time")]
+
+        if not unassigned_matches:
+            logger.info("[CONFLICT-RESOLVER] No unassigned matches - no conflicts to resolve.")
+            return False
+
+        logger.info(f"[CONFLICT-RESOLVER] Found {len(unassigned_matches)} unassigned matches")
+
+        # Generate slot matrix to check which matches have NO availability overlap
+        slot_matrix = generate_slot_matrix(tournament)
+
+        conflicts = []
+        for match in unassigned_matches:
+            team1 = match["team1"]
+            team2 = match["team2"]
+            match_id = match["match_id"]
+
+            # Check if teams have ANY common availability
+            valid_slots = get_valid_slots_for_match(team1, team2, slot_matrix)
+
+            if not valid_slots:
+                # No common availability at all - this is a conflict!
+                logger.warning(
+                    f"[CONFLICT-RESOLVER] Match {match_id} ({team1} vs {team2}) "
+                    f"has NO overlapping availability!"
+                )
+                conflicts.append(match)
+            else:
+                logger.info(
+                    f"[CONFLICT-RESOLVER] Match {match_id} ({team1} vs {team2}) "
+                    f"has {len(valid_slots)} potential slots (not a conflict, just scheduling issue)"
+                )
+
+        if not conflicts:
+            logger.info("[CONFLICT-RESOLVER] No availability conflicts found - all unassigned matches have potential slots.")
+            return False
+
+        # Conflicts found - notify and start resolution process
+        logger.warning(f"[CONFLICT-RESOLVER] Found {len(conflicts)} matches with availability conflicts!")
+        await self.channel.send(
+            f"⚠️ **Availability Conflicts Detected**\n"
+            f"Found {len(conflicts)} match(es) where teams have no overlapping availability.\n"
+            f"Starting conflict resolution process..."
+        )
+
+        # Start resolution for each conflict
+        for match in conflicts:
+            await self._initiate_conflict_resolution(match)
+
+        return True
+
+    async def _initiate_conflict_resolution(self, match: dict):
+        """
+        Start the resolution process for a single match conflict.
+
+        :param match: Match data dict
+        """
+        match_id = match["match_id"]
+        team1 = match["team1"]
+        team2 = match["team2"]
+
+        if match_id in self.pending_resolutions:
+            logger.warning(f"[CONFLICT-RESOLVER] Match {match_id} already has pending resolution")
+            return
+
+        self.pending_resolutions.add(match_id)
+
+        tournament = load_tournament_data()
+        teams = tournament.get("teams", {})
+        team1_data = teams.get(team1, {})
+        team2_data = teams.get(team2, {})
+
+        # Get team members
+        team1_members = await self._get_team_members(team1, team1_data)
+        team2_members = await self._get_team_members(team2, team2_data)
+
+        if not team1_members or not team2_members:
+            logger.error(
+                f"[CONFLICT-RESOLVER] Could not find members for match {match_id}. "
+                f"Skipping conflict resolution."
+            )
+            self.pending_resolutions.discard(match_id)
+            return
+
+        # Generate time slot suggestions
+        tz = ZoneInfo(CONFIG.bot.timezone)
+        tournament_start = datetime.fromisoformat(tournament["registration_end"])
+        tournament_end = datetime.fromisoformat(tournament["tournament_end"])
+
+        if tournament_start.tzinfo is None:
+            tournament_start = tournament_start.replace(tzinfo=tz)
+        if tournament_end.tzinfo is None:
+            tournament_end = tournament_end.replace(tzinfo=tz)
+
+        suggested_slots = generate_availability_suggestions(
+            team1_data,
+            team2_data,
+            tournament_start,
+            tournament_end,
+            count=10
+        )
+
+        logger.info(
+            f"[CONFLICT-RESOLVER] Generated {len(suggested_slots)} suggestions "
+            f"for match {match_id}"
+        )
+
+        # Create embed for conflict notification
+        embed = discord.Embed(
+            title=f"⚠️ Availability Conflict - Match {match_id}",
+            description=(
+                f"**{team1}** vs **{team2}**\n\n"
+                f"Your teams have no overlapping availability in their registered time windows.\n\n"
+                f"**Options:**\n"
+                f"1️⃣ Select a suggested time slot below that works for both teams\n"
+                f"2️⃣ All players must confirm the selected time\n"
+                f"3️⃣ Decline to withdraw your team from the tournament\n\n"
+                f"⏰ **Deadline:** 48 hours\n"
+                f"If no agreement is reached, both teams will be excluded."
+            ),
+            color=discord.Color.orange()
+        )
+
+        # Add team availability info
+        team1_avail_str = self._format_availability(team1_data.get("availability", {}))
+        team2_avail_str = self._format_availability(team2_data.get("availability", {}))
+
+        embed.add_field(
+            name=f"📅 {team1} - Current Availability",
+            value=team1_avail_str or "No availability set",
+            inline=False
+        )
+        embed.add_field(
+            name=f"📅 {team2} - Current Availability",
+            value=team2_avail_str or "No availability set",
+            inline=False
+        )
+
+        # Create view
+        view = AvailabilityConflictView(
+            match_id=match_id,
+            team1=team1,
+            team2=team2,
+            team1_members=team1_members,
+            team2_members=team2_members,
+            suggested_slots=suggested_slots,
+            on_resolution_callback=self._handle_resolution
+        )
+
+        # Send message with view
+        message = await self.channel.send(
+            content=f"🔔 {' '.join(m.mention for m in team1_members + team2_members)}",
+            embed=embed,
+            view=view
+        )
+        view.message = message
+
+        logger.info(f"[CONFLICT-RESOLVER] Sent conflict resolution request for match {match_id}")
+
+    async def _get_team_members(self, team_name: str, team_data: dict) -> List[discord.Member]:
+        """
+        Get Discord Member objects for a team.
+
+        :param team_name: Team name
+        :param team_data: Team data dict
+        :return: List of Member objects
+        """
+        members = []
+        for member_mention in team_data.get("members", []):
+            try:
+                user_id = int(member_mention.strip("<@!>"))
+                member = self.channel.guild.get_member(user_id)
+                if member:
+                    members.append(member)
+                else:
+                    logger.warning(
+                        f"[CONFLICT-RESOLVER] Could not find member {user_id} in guild"
+                    )
+            except (ValueError, AttributeError) as e:
+                logger.error(
+                    f"[CONFLICT-RESOLVER] Error parsing member mention {member_mention}: {e}"
+                )
+
+        return members
+
+    def _format_availability(self, availability: dict) -> str:
+        """
+        Format availability dict for display.
+
+        :param availability: Availability dict
+        :return: Formatted string
+        """
+        if not availability:
+            return "No times set"
+
+        lines = []
+        for day in ["saturday", "sunday", "monday", "tuesday", "wednesday", "thursday", "friday"]:
+            time_range = availability.get(day, "00:00-00:00")
+            if time_range != "00:00-00:00":
+                lines.append(f"• {day.capitalize()}: {time_range}")
+
+        return "\n".join(lines) if lines else "No availability"
+
+    async def _handle_resolution(
+        self,
+        match_id: int,
+        team1: str,
+        team2: str,
+        selected_slot: Optional[datetime] = None,
+        excluded_team: Optional[str] = None
+    ):
+        """
+        Handle the resolution of a conflict.
+
+        :param match_id: Match ID
+        :param team1: First team name
+        :param team2: Second team name
+        :param selected_slot: Agreed time slot (if any)
+        :param excluded_team: Team to exclude ("both", team name, or None)
+        """
+        logger.info(
+            f"[CONFLICT-RESOLVER] Handling resolution for match {match_id}: "
+            f"slot={selected_slot}, excluded={excluded_team}"
+        )
+
+        tournament = load_tournament_data()
+        teams = tournament.get("teams", {})
+
+        if excluded_team:
+            # Handle team exclusion
+            teams_to_exclude = []
+
+            if excluded_team == "both":
+                teams_to_exclude = [team1, team2]
+            else:
+                teams_to_exclude = [excluded_team]
+
+            for team in teams_to_exclude:
+                if team not in self.excluded_teams:
+                    self.excluded_teams.add(team)
+                    await self._exclude_team(team)
+
+        elif selected_slot:
+            # Update team availability to include the selected slot
+            await self._update_team_availability(team1, team2, selected_slot)
+            self.resolved_matches[match_id] = selected_slot
+
+        self.pending_resolutions.discard(match_id)
+
+        # Check if all conflicts are resolved
+        if not self.pending_resolutions:
+            await self._finalize_all_resolutions()
+
+    async def _exclude_team(self, team_name: str):
+        """
+        Exclude a team from the tournament by forfeiting all their matches.
+
+        :param team_name: Team to exclude
+        """
+        logger.warning(f"[CONFLICT-RESOLVER] Excluding team {team_name} from tournament")
+
+        tournament = load_tournament_data()
+        teams = tournament.get("teams", {})
+
+        # Mark team as excluded
+        if team_name in teams:
+            teams[team_name]["status"] = "excluded"
+            teams[team_name]["excluded_reason"] = "availability_conflict"
+
+        # Forfeit all open matches for this team
+        forfeited_count = 0
+        for match in tournament.get("matches", []):
+            if match.get("status") == "open" and team_name in (match.get("team1"), match.get("team2")):
+                match["status"] = "forfeit"
+                match["forfeit_by"] = team_name
+
+                # Opponent wins (unless also excluded)
+                opponent = match["team2"] if match["team1"] == team_name else match["team1"]
+                opponent_status = teams.get(opponent, {}).get("status")
+
+                if opponent_status in ("excluded", "withdrawn"):
+                    match["winner"] = "None (both teams excluded/withdrawn)"
+                else:
+                    match["winner"] = opponent
+
+                forfeited_count += 1
+
+        save_tournament_data(tournament)
+
+        await self.channel.send(
+            f"⚠️ Team **{team_name}** has been excluded from the tournament.\n"
+            f"📊 {forfeited_count} match(es) forfeited."
+        )
+
+        logger.info(f"[CONFLICT-RESOLVER] Team {team_name} excluded, {forfeited_count} matches forfeited")
+
+    async def _update_team_availability(self, team1: str, team2: str, slot: datetime):
+        """
+        Update both teams' availability to include the agreed time slot.
+
+        :param team1: First team name
+        :param team2: Second team name
+        :param slot: Agreed datetime slot
+        """
+        logger.info(
+            f"[CONFLICT-RESOLVER] Updating availability for {team1} and {team2} "
+            f"to include slot {slot}"
+        )
+
+        tournament = load_tournament_data()
+        teams = tournament.get("teams", {})
+
+        # Determine day and time
+        weekday = slot.weekday()
+        day_key = AvailabilityChecker.DAY_NAMES[weekday]
+        slot_time = slot.strftime("%H:%M")
+
+        # Add 2-hour window around the slot
+        from datetime import timedelta
+        start_time = (slot - timedelta(hours=1)).strftime("%H:%M")
+        end_time = (slot + timedelta(hours=1)).strftime("%H:%M")
+        new_range = f"{start_time}-{end_time}"
+
+        # Update both teams
+        for team_name in [team1, team2]:
+            if team_name in teams:
+                availability = teams[team_name].get("availability", {})
+                current_range = availability.get(day_key, "00:00-00:00")
+
+                if current_range == "00:00-00:00":
+                    # No existing availability on this day - set it
+                    availability[day_key] = new_range
+                else:
+                    # Merge with existing availability
+                    availability[day_key] = self._merge_time_ranges(current_range, new_range)
+
+                teams[team_name]["availability"] = availability
+                logger.info(
+                    f"[CONFLICT-RESOLVER] Updated {team_name} availability for {day_key}: "
+                    f"{availability[day_key]}"
+                )
+
+        save_tournament_data(tournament)
+
+        await self.channel.send(
+            f"✅ Updated availability for **{team1}** and **{team2}** to include "
+            f"**{slot.strftime('%A %d.%m.%Y %H:%M')}**"
+        )
+
+    def _merge_time_ranges(self, range1: str, range2: str) -> str:
+        """
+        Merge two time ranges into a single encompassing range.
+
+        :param range1: First time range (e.g., "14:00-18:00")
+        :param range2: Second time range (e.g., "16:00-20:00")
+        :return: Merged range (e.g., "14:00-20:00")
+        """
+        try:
+            start1, end1 = AvailabilityChecker.parse_time_range(range1)
+            start2, end2 = AvailabilityChecker.parse_time_range(range2)
+
+            earliest_start = min(start1, start2)
+            latest_end = max(end1, end2)
+
+            return f"{earliest_start.strftime('%H:%M')}-{latest_end.strftime('%H:%M')}"
+        except ValueError as e:
+            logger.error(f"[CONFLICT-RESOLVER] Error merging time ranges: {e}")
+            return range2  # Fall back to new range
+
+    async def _finalize_all_resolutions(self):
+        """
+        Called when all conflicts are resolved.
+        Regenerates the schedule and publishes it.
+        """
+        logger.info("[CONFLICT-RESOLVER] All conflicts resolved! Regenerating schedule...")
+
+        await self.channel.send(
+            "✅ All availability conflicts have been resolved!\n"
+            "🔄 Regenerating tournament schedule..."
+        )
+
+        # Regenerate schedule with updated availability
+        from modules.matchmaker import generate_and_assign_slots, generate_schedule_overview
+
+        await generate_and_assign_slots()
+
+        # Reload and display schedule
+        tournament = load_tournament_data()
+        matches = tournament.get("matches", [])
+
+        from modules.embeds import send_match_schedule_for_channel
+        description_text = generate_schedule_overview(matches)
+        await send_match_schedule_for_channel(self.channel, description_text)
+
+        logger.info("[CONFLICT-RESOLVER] Schedule regenerated and published!")

--- a/modules/availability_conflict_view.py
+++ b/modules/availability_conflict_view.py
@@ -1,0 +1,374 @@
+"""
+Availability Conflict Resolution System
+
+Handles cases where teams have no overlapping availability.
+Provides suggestions for alternative time slots and manages team responses.
+"""
+
+from discord import ui, ButtonStyle, Interaction, Member, SelectOption, Embed
+from typing import List, Dict, Set, Optional
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+import asyncio
+
+from modules.dataStorage import load_tournament_data, save_tournament_data
+from modules.logger import logger
+from modules.config import CONFIG
+from modules.matchmaker import AvailabilityChecker
+
+
+class AvailabilityConflictView(ui.View):
+    """
+    View for resolving availability conflicts between teams.
+    Both teams must agree to a proposed time slot, or they will be excluded.
+    """
+
+    def __init__(
+        self,
+        match_id: int,
+        team1: str,
+        team2: str,
+        team1_members: List[Member],
+        team2_members: List[Member],
+        suggested_slots: List[datetime],
+        on_resolution_callback
+    ):
+        super().__init__(timeout=172800)  # 48 hours timeout
+        self.match_id = match_id
+        self.team1 = team1
+        self.team2 = team2
+        self.team1_members = team1_members
+        self.team2_members = team2_members
+        self.all_members = team1_members + team2_members
+        self.suggested_slots = suggested_slots
+        self.on_resolution_callback = on_resolution_callback
+
+        self.approved = set()  # Track who approved
+        self.selected_slot = None
+        self.message = None
+
+        # Create select menu with suggested slots
+        self._add_slot_selector()
+
+    def _add_slot_selector(self):
+        """Add dropdown menu with time slot suggestions."""
+        options = []
+
+        # Add up to 10 suggested slots
+        for i, slot in enumerate(self.suggested_slots[:10]):
+            label = slot.strftime("%a %d.%m.%Y %H:%M")
+            value = slot.isoformat()
+            options.append(SelectOption(
+                label=label,
+                value=value,
+                description=f"Option {i+1}"
+            ))
+
+        if not options:
+            options.append(SelectOption(
+                label="No suggestions available",
+                value="none",
+                description="Cannot find common time"
+            ))
+
+        select = ui.Select(
+            placeholder="Select a time slot that works for both teams...",
+            options=options,
+            min_values=1,
+            max_values=1
+        )
+        select.callback = self.slot_selected
+        self.add_item(select)
+
+    async def interaction_check(self, interaction: Interaction) -> bool:
+        """Only team members can interact."""
+        if interaction.user not in self.all_members:
+            await interaction.response.send_message(
+                "🚫 You are not part of this match.",
+                ephemeral=True
+            )
+            return False
+        return True
+
+    async def slot_selected(self, interaction: Interaction):
+        """Called when a slot is selected from dropdown."""
+        selected_value = interaction.data["values"][0]
+
+        if selected_value == "none":
+            await interaction.response.send_message(
+                "❌ No time slots available. Please decline to withdraw from the tournament.",
+                ephemeral=True
+            )
+            return
+
+        self.selected_slot = datetime.fromisoformat(selected_value)
+
+        await interaction.response.send_message(
+            f"✅ You selected: **{self.selected_slot.strftime('%A %d.%m.%Y %H:%M')}**\n"
+            f"Waiting for all players to confirm...",
+            ephemeral=True
+        )
+
+        # Automatically "approve" for this user
+        if interaction.user not in self.approved:
+            self.approved.add(interaction.user)
+            logger.info(
+                f"[AVAILABILITY-CONFLICT] {interaction.user.display_name} selected and approved "
+                f"slot {self.selected_slot} for match {self.match_id}"
+            )
+
+        # Check if all players approved
+        await self._check_full_approval()
+
+    @ui.button(label="✅ Confirm Selected Time", style=ButtonStyle.success)
+    async def confirm(self, interaction: Interaction, button: ui.Button):
+        """Confirm the currently selected time slot."""
+        if not self.selected_slot:
+            await interaction.response.send_message(
+                "⚠️ Please select a time slot first using the dropdown menu above.",
+                ephemeral=True
+            )
+            return
+
+        if interaction.user in self.approved:
+            await interaction.response.send_message(
+                "✅ You already confirmed this time slot.",
+                ephemeral=True
+            )
+            return
+
+        self.approved.add(interaction.user)
+        logger.info(
+            f"[AVAILABILITY-CONFLICT] {interaction.user.display_name} confirmed "
+            f"slot {self.selected_slot} for match {self.match_id}"
+        )
+
+        await interaction.response.send_message(
+            f"✅ Confirmed! ({len(self.approved)}/{len(self.all_members)} players)",
+            ephemeral=True
+        )
+
+        # Check if all players approved
+        await self._check_full_approval()
+
+    @ui.button(label="❌ Decline (Withdraw from Tournament)", style=ButtonStyle.danger)
+    async def decline(self, interaction: Interaction, button: ui.Button):
+        """
+        Decline to adjust availability.
+        This will withdraw the declining player's team from the tournament.
+        """
+        await interaction.response.defer()
+
+        # Determine which team the declining player belongs to
+        tournament = load_tournament_data()
+        teams = tournament.get("teams", {})
+
+        decliner_team = None
+        if interaction.user in self.team1_members:
+            decliner_team = self.team1
+        elif interaction.user in self.team2_members:
+            decliner_team = self.team2
+
+        if not decliner_team:
+            logger.error(
+                f"[AVAILABILITY-CONFLICT] Could not find team for declining player "
+                f"{interaction.user.mention}"
+            )
+            await interaction.followup.send(
+                "❌ Error: Could not determine your team.",
+                ephemeral=True
+            )
+            return
+
+        logger.warning(
+            f"[AVAILABILITY-CONFLICT] {interaction.user.display_name} from team "
+            f"{decliner_team} DECLINED to adjust availability for match {self.match_id}"
+        )
+
+        # Mark team as excluded (will be handled by callback)
+        opponent = self.team2 if decliner_team == self.team1 else self.team1
+
+        if self.message:
+            await self.message.edit(
+                content=(
+                    f"❌ **{interaction.user.mention}** (Team **{decliner_team}**) declined to adjust availability.\n"
+                    f"⚠️ Team **{decliner_team}** will be excluded from the tournament.\n"
+                    f"🏆 Team **{opponent}** receives a walkover for this match."
+                ),
+                embed=None,
+                view=None
+            )
+
+        # Call resolution callback with exclusion
+        await self.on_resolution_callback(
+            self.match_id,
+            decliner_team,
+            None,
+            excluded_team=decliner_team
+        )
+
+        self.stop()
+
+    async def _check_full_approval(self):
+        """Check if all players have approved the selected slot."""
+        if self.approved == set(self.all_members):
+            await self._finalize_resolution()
+
+    async def _finalize_resolution(self):
+        """All players agreed - update availability and reschedule."""
+        logger.info(
+            f"[AVAILABILITY-CONFLICT] All players approved slot {self.selected_slot} "
+            f"for match {self.match_id}. Updating availability..."
+        )
+
+        if self.message:
+            await self.message.edit(
+                content=(
+                    f"✅ All players agreed to the new time slot!\n"
+                    f"📅 Match {self.match_id} will be scheduled for "
+                    f"**{self.selected_slot.strftime('%A %d.%m.%Y %H:%M')}**\n"
+                    f"⏳ Updating team availability and regenerating schedule..."
+                ),
+                embed=None,
+                view=None
+            )
+
+        # Call resolution callback
+        await self.on_resolution_callback(
+            self.match_id,
+            self.team1,
+            self.team2,
+            self.selected_slot
+        )
+
+        self.stop()
+
+    async def on_timeout(self):
+        """
+        Timeout after 48 hours - both teams will be excluded.
+        """
+        logger.warning(
+            f"[AVAILABILITY-CONFLICT] Timeout for match {self.match_id}. "
+            f"Both teams ({self.team1}, {self.team2}) will be excluded."
+        )
+
+        if self.message:
+            await self.message.edit(
+                content=(
+                    f"⌛ **Timeout!**\n"
+                    f"No agreement was reached within 48 hours.\n"
+                    f"⚠️ Both teams (**{self.team1}**, **{self.team2}**) will be excluded from the tournament."
+                ),
+                embed=None,
+                view=None
+            )
+
+        # Exclude both teams
+        await self.on_resolution_callback(
+            self.match_id,
+            self.team1,
+            self.team2,
+            None,
+            excluded_team="both"
+        )
+
+        self.stop()
+
+
+def generate_availability_suggestions(
+    team1_data: dict,
+    team2_data: dict,
+    tournament_start: datetime,
+    tournament_end: datetime,
+    count: int = 10
+) -> List[datetime]:
+    """
+    Generate suggested time slots for teams with no overlapping availability.
+
+    Strategy:
+    1. Find times when at least one team is available
+    2. Prefer times when both teams have partial availability
+    3. Spread suggestions across different days
+
+    :param team1_data: Team 1 tournament data
+    :param team2_data: Team 2 tournament data
+    :param tournament_start: Tournament start datetime
+    :param tournament_end: Tournament end datetime
+    :param count: Number of suggestions to generate
+    :return: List of suggested datetime slots
+    """
+    suggestions = []
+    tz = ZoneInfo(CONFIG.bot.timezone)
+
+    # Ensure timezone awareness
+    if tournament_start.tzinfo is None:
+        tournament_start = tournament_start.replace(tzinfo=tz)
+    if tournament_end.tzinfo is None:
+        tournament_end = tournament_end.replace(tzinfo=tz)
+
+    team1_avail = team1_data.get("availability", {})
+    team2_avail = team2_data.get("availability", {})
+
+    # Collect all time ranges from both teams
+    all_ranges = set()
+    for day, time_range in team1_avail.items():
+        if time_range != "00:00-00:00":
+            all_ranges.add((day, time_range))
+    for day, time_range in team2_avail.items():
+        if time_range != "00:00-00:00":
+            all_ranges.add((day, time_range))
+
+    current = tournament_start
+    while current <= tournament_end and len(suggestions) < count:
+        weekday = current.weekday()
+        day_key = AvailabilityChecker.DAY_NAMES[weekday]
+
+        # Check if this day has any availability for either team
+        team1_range = team1_avail.get(day_key, "00:00-00:00")
+        team2_range = team2_avail.get(day_key, "00:00-00:00")
+
+        if team1_range != "00:00-00:00" or team2_range != "00:00-00:00":
+            # At least one team has availability on this day
+            # Suggest midpoint times in each team's availability
+
+            if team1_range != "00:00-00:00":
+                try:
+                    start, end = AvailabilityChecker.parse_time_range(team1_range)
+                    # Calculate midpoint
+                    start_dt = datetime.combine(current.date(), start, tzinfo=tz)
+                    end_dt = datetime.combine(current.date(), end, tzinfo=tz)
+                    midpoint = start_dt + (end_dt - start_dt) / 2
+
+                    if midpoint not in suggestions:
+                        suggestions.append(midpoint)
+                except ValueError:
+                    pass
+
+            if team2_range != "00:00-00:00" and len(suggestions) < count:
+                try:
+                    start, end = AvailabilityChecker.parse_time_range(team2_range)
+                    start_dt = datetime.combine(current.date(), start, tzinfo=tz)
+                    end_dt = datetime.combine(current.date(), end, tzinfo=tz)
+                    midpoint = start_dt + (end_dt - start_dt) / 2
+
+                    if midpoint not in suggestions:
+                        suggestions.append(midpoint)
+                except ValueError:
+                    pass
+
+        current += timedelta(days=1)
+
+    # If we don't have enough suggestions, add some standard times
+    if len(suggestions) < count:
+        current = tournament_start
+        while current <= tournament_end and len(suggestions) < count:
+            # Add standard times: 14:00, 18:00, 20:00
+            for hour in [14, 18, 20]:
+                suggestion = current.replace(hour=hour, minute=0, second=0, microsecond=0)
+                if suggestion not in suggestions and tournament_start <= suggestion <= tournament_end:
+                    suggestions.append(suggestion)
+                    if len(suggestions) >= count:
+                        break
+            current += timedelta(days=1)
+
+    return sorted(suggestions)[:count]


### PR DESCRIPTION
When teams have no overlapping availability:
- Detect conflicts after slot assignment
- Delay schedule publication until resolution
- Offer suggested time slots to both teams
- Require all players to confirm selected slot
- 48-hour deadline with button interface
- Auto-exclude teams if no agreement reached
- Regenerate schedule after resolution

Features:
- Interactive Discord UI with dropdown slot selection
- Smart suggestions based on partial team availability
- Automatic availability updates when teams agree
- Proper forfeit handling for excluded teams
- Handles both single team and mutual exclusions

This prevents tournaments from starting with unschedulable matches and gives teams a chance to find common ground.