### PR TITLE
Add: Locale templates for new features (EN + DE)

### DIFF
--- a/locale/de/embeds/availability_conflict.json
+++ b/locale/de/embeds/availability_conflict.json
@@ -1,0 +1,40 @@
+{
+  "CONFLICT_NOTIFICATION": {
+    "title": "⚠️ Verfügbarkeitskonflikt - Match PLACEHOLDER_MATCH_ID",
+    "description": "**PLACEHOLDER_TEAM1** vs **PLACEHOLDER_TEAM2**\n\nEure Teams haben keine überschneidende Verfügbarkeit in ihren registrierten Zeitfenstern.\n\n**Optionen:**\n1️⃣ Wähle unten einen vorgeschlagenen Zeitslot, der für beide Teams passt\n2️⃣ Alle Spieler müssen den gewählten Zeitpunkt bestätigen\n3️⃣ Lehne ab, um dein Team vom Turnier zurückzuziehen\n\n⏰ **Deadline:** 48 Stunden\nWenn keine Einigung erreicht wird, werden beide Teams ausgeschlossen.",
+    "color": "0xFF9800",
+    "fields": [
+      {
+        "name": "📅 PLACEHOLDER_TEAM1 - Aktuelle Verfügbarkeit",
+        "value": "PLACEHOLDER_TEAM1_AVAIL",
+        "inline": false
+      },
+      {
+        "name": "📅 PLACEHOLDER_TEAM2 - Aktuelle Verfügbarkeit",
+        "value": "PLACEHOLDER_TEAM2_AVAIL",
+        "inline": false
+      }
+    ]
+  },
+  "MESSAGES": {
+    "conflicts_detected": "⚠️ **Verfügbarkeitskonflikte erkannt**\nPLACEHOLDER_COUNT Match(es) gefunden, bei denen Teams keine überschneidende Verfügbarkeit haben.\nStarte Konfliktlösungsprozess...",
+    "select_placeholder": "Wähle einen Zeitslot, der für beide Teams passt...",
+    "option_label": "Option PLACEHOLDER_NUM",
+    "no_suggestions": "Keine Vorschläge verfügbar",
+    "no_suggestions_desc": "Kann keine gemeinsame Zeit finden",
+    "selected_slot": "✅ Du hast gewählt: **PLACEHOLDER_SLOT**\nWarte auf Bestätigung aller Spieler...",
+    "no_slot_selected": "⚠️ Bitte wähle zuerst einen Zeitslot aus dem Dropdown-Menü oben.",
+    "already_confirmed": "✅ Du hast diesen Zeitslot bereits bestätigt.",
+    "confirmed_count": "✅ Bestätigt! (PLACEHOLDER_CURRENT/PLACEHOLDER_TOTAL Spieler)",
+    "not_part_of_match": "🚫 Du bist nicht Teil dieses Matches.",
+    "all_agreed": "✅ Alle Spieler haben dem neuen Zeitslot zugestimmt!\n📅 Match PLACEHOLDER_MATCH_ID wird für **PLACEHOLDER_SLOT** geplant\n⏳ Aktualisiere Team-Verfügbarkeit und generiere Spielplan neu...",
+    "declined_team": "❌ **PLACEHOLDER_USER** (Team **PLACEHOLDER_TEAM**) hat abgelehnt, die Verfügbarkeit anzupassen.\n⚠️ Team **PLACEHOLDER_TEAM** wird vom Turnier ausgeschlossen.\n🏆 Team **PLACEHOLDER_OPPONENT** erhält kampflos den Sieg für dieses Match.",
+    "timeout_both": "⌛ **Zeitüberschreitung!**\nKeine Einigung wurde innerhalb von 48 Stunden erreicht.\n⚠️ Beide Teams (**PLACEHOLDER_TEAM1**, **PLACEHOLDER_TEAM2**) werden vom Turnier ausgeschlossen.",
+    "team_excluded": "⚠️ Team **PLACEHOLDER_TEAM** wurde vom Turnier ausgeschlossen.\n📊 PLACEHOLDER_COUNT Match(es) aufgegeben.",
+    "availability_updated": "✅ Verfügbarkeit für **PLACEHOLDER_TEAM1** und **PLACEHOLDER_TEAM2** aktualisiert, um **PLACEHOLDER_SLOT** einzuschließen",
+    "all_resolved": "✅ Alle Verfügbarkeitskonflikte wurden gelöst!\n🔄 Generiere Turnier-Spielplan neu...",
+    "schedule_pending": "⏸️ **Turnier-Spielplan ausstehend**\nWarte auf Lösung der Verfügbarkeitskonflikte.\nDer Spielplan wird automatisch veröffentlicht, sobald alle Teams geantwortet haben.",
+    "no_availability": "Keine Verfügbarkeit gesetzt",
+    "no_times_set": "Keine Zeiten gesetzt"
+  }
+}

--- a/locale/de/embeds/leave_confirmation.json
+++ b/locale/de/embeds/leave_confirmation.json
@@ -1,0 +1,69 @@
+{
+  "LEAVE_DURING_REGISTRATION": {
+    "title": "⚠️ Turnier verlassen - Bestätigung",
+    "description": "Du bist dabei, das Team **PLACEHOLDER_TEAM_NAME** zu verlassen.\n\n**Was wird passieren:**",
+    "color": "0xFF9800",
+    "fields": [
+      {
+        "name": "📋 Konsequenzen",
+        "value": "PLACEHOLDER_CONSEQUENCES",
+        "inline": false
+      },
+      {
+        "name": "✅ Sicher zum Verlassen",
+        "value": "Die Anmeldung ist noch offen, daher gibt es keine Strafen fürs Verlassen.",
+        "inline": false
+      }
+    ],
+    "footer": "⏰ Du hast 60 Sekunden Zeit zu entscheiden."
+  },
+  "LEAVE_AFTER_REGISTRATION": {
+    "title": "🚨 Turnier verlassen - WARNUNG",
+    "description": "Du bist dabei, das Team **PLACEHOLDER_TEAM_NAME** zu verlassen.\n\n**⚠️ SCHWERWIEGENDE KONSEQUENZEN - LIES SORGFÄLTIG:**",
+    "color": "0xE74C3C",
+    "fields": [
+      {
+        "name": "⚠️ Konsequenzen",
+        "value": "PLACEHOLDER_CONSEQUENCES",
+        "inline": false
+      },
+      {
+        "name": "👥 Auswirkung auf Partner",
+        "value": "PLACEHOLDER_PARTNER_IMPACT",
+        "inline": false
+      },
+      {
+        "name": "🛑 Bist du dir absolut sicher?",
+        "value": "Fahre nur fort, wenn du nicht weiter am Turnier teilnehmen kannst.\nÜberlege dir, vorher mit deinem Partner zu sprechen, falls zutreffend.",
+        "inline": false
+      }
+    ],
+    "footer": "⏰ Du hast 60 Sekunden Zeit zu entscheiden."
+  },
+  "MESSAGES": {
+    "consequences_team_dissolved": "🔹 Dein Team wird **aufgelöst**",
+    "consequences_partner_solo": "🔹 Dein Partner (PLACEHOLDER_PARTNER) wird in die **Solo-Warteschlange** verschoben",
+    "consequences_partner_rematched": "🔹 Er kann mit einem anderen Solo-Spieler gematcht werden",
+    "consequences_removed": "🔹 Du wirst **komplett** aus dem Turnier entfernt",
+    "consequences_can_rejoin": "🔹 Du kannst dich jederzeit **neu anmelden**, bevor die Anmeldung schließt",
+    "consequences_withdrawn": "🔹 Dein Team wird als **ZURÜCKGEZOGEN** markiert",
+    "consequences_forfeited": "🔹 **PLACEHOLDER_MATCH_COUNT Match(es)** werden **aufgegeben**",
+    "consequences_auto_loss": "🔹 Alle aufgegebenen Matches zählen als **automatische Niederlagen**",
+    "consequences_auto_win": "🔹 Deine Gegner erhalten **automatische Siege**",
+    "consequences_partner_eliminated": "🔹 Dein Partner (PLACEHOLDER_PARTNER) wird ebenfalls **eliminiert**",
+    "consequences_irreversible": "🔹 Diese Aktion **KANN NICHT RÜCKGÄNGIG GEMACHT WERDEN**",
+    "consequences_no_rejoin": "🔹 Du **KANNST NICHT** wieder diesem Turnier beitreten",
+    "partner_impact_text": "Dein Partner wird benachrichtigt und das gesamte Team wird zurückgezogen.\nIhr werdet beide aus dem Turnier entfernt.",
+    "partner_impact_none": "Dein gesamtes Team wird aus dem Turnier entfernt.",
+    "button_confirm": "✅ Ja, Turnier verlassen",
+    "button_cancel": "❌ Abbrechen",
+    "confirm_left": "✅ Du hast das Team **PLACEHOLDER_TEAM_NAME** erfolgreich verlassen.",
+    "confirm_left_forfeited": "✅ Du hast das Team **PLACEHOLDER_TEAM_NAME** verlassen.\n⚠️ Das Team wurde zurückgezogen und **PLACEHOLDER_MATCH_COUNT Match(es)** aufgegeben.",
+    "cancelled": "❌ Verlassen-Vorgang abgebrochen.",
+    "already_cancelled": "✅ Abgebrochen. Du bleibst im Turnier.",
+    "timeout": "⌛ Verlassen-Bestätigung ist abgelaufen. Du bleibst im Turnier.",
+    "only_initiator": "🚫 Nur die Person, die dies initiiert hat, kann bestätigen.",
+    "only_initiator_cancel": "🚫 Nur die Person, die dies initiiert hat, kann abbrechen.",
+    "partner_notification": "⚠️ PLACEHOLDER_PARTNER: Dein Teamkollege hat das Turnier verlassen. Team **PLACEHOLDER_TEAM_NAME** wurde zurückgezogen und alle Matches aufgegeben."
+  }
+}

--- a/locale/en/embeds/availability_conflict.json
+++ b/locale/en/embeds/availability_conflict.json
@@ -1,0 +1,40 @@
+{
+  "CONFLICT_NOTIFICATION": {
+    "title": "⚠️ Availability Conflict - Match PLACEHOLDER_MATCH_ID",
+    "description": "**PLACEHOLDER_TEAM1** vs **PLACEHOLDER_TEAM2**\n\nYour teams have no overlapping availability in their registered time windows.\n\n**Options:**\n1️⃣ Select a suggested time slot below that works for both teams\n2️⃣ All players must confirm the selected time\n3️⃣ Decline to withdraw your team from the tournament\n\n⏰ **Deadline:** 48 hours\nIf no agreement is reached, both teams will be excluded.",
+    "color": "0xFF9800",
+    "fields": [
+      {
+        "name": "📅 PLACEHOLDER_TEAM1 - Current Availability",
+        "value": "PLACEHOLDER_TEAM1_AVAIL",
+        "inline": false
+      },
+      {
+        "name": "📅 PLACEHOLDER_TEAM2 - Current Availability",
+        "value": "PLACEHOLDER_TEAM2_AVAIL",
+        "inline": false
+      }
+    ]
+  },
+  "MESSAGES": {
+    "conflicts_detected": "⚠️ **Availability Conflicts Detected**\nFound PLACEHOLDER_COUNT match(es) where teams have no overlapping availability.\nStarting conflict resolution process...",
+    "select_placeholder": "Select a time slot that works for both teams...",
+    "option_label": "Option PLACEHOLDER_NUM",
+    "no_suggestions": "No suggestions available",
+    "no_suggestions_desc": "Cannot find common time",
+    "selected_slot": "✅ You selected: **PLACEHOLDER_SLOT**\nWaiting for all players to confirm...",
+    "no_slot_selected": "⚠️ Please select a time slot first using the dropdown menu above.",
+    "already_confirmed": "✅ You already confirmed this time slot.",
+    "confirmed_count": "✅ Confirmed! (PLACEHOLDER_CURRENT/PLACEHOLDER_TOTAL players)",
+    "not_part_of_match": "🚫 You are not part of this match.",
+    "all_agreed": "✅ All players agreed to the new time slot!\n📅 Match PLACEHOLDER_MATCH_ID will be scheduled for **PLACEHOLDER_SLOT**\n⏳ Updating team availability and regenerating schedule...",
+    "declined_team": "❌ **PLACEHOLDER_USER** (Team **PLACEHOLDER_TEAM**) declined to adjust availability.\n⚠️ Team **PLACEHOLDER_TEAM** will be excluded from the tournament.\n🏆 Team **PLACEHOLDER_OPPONENT** receives a walkover for this match.",
+    "timeout_both": "⌛ **Timeout!**\nNo agreement was reached within 48 hours.\n⚠️ Both teams (**PLACEHOLDER_TEAM1**, **PLACEHOLDER_TEAM2**) will be excluded from the tournament.",
+    "team_excluded": "⚠️ Team **PLACEHOLDER_TEAM** has been excluded from the tournament.\n📊 PLACEHOLDER_COUNT match(es) forfeited.",
+    "availability_updated": "✅ Updated availability for **PLACEHOLDER_TEAM1** and **PLACEHOLDER_TEAM2** to include **PLACEHOLDER_SLOT**",
+    "all_resolved": "✅ All availability conflicts have been resolved!\n🔄 Regenerating tournament schedule...",
+    "schedule_pending": "⏸️ **Tournament schedule pending**\nWaiting for availability conflicts to be resolved.\nThe schedule will be published automatically once all teams have responded.",
+    "no_availability": "No availability set",
+    "no_times_set": "No times set"
+  }
+}

--- a/locale/en/embeds/leave_confirmation.json
+++ b/locale/en/embeds/leave_confirmation.json
@@ -1,0 +1,69 @@
+{
+  "LEAVE_DURING_REGISTRATION": {
+    "title": "⚠️ Leave Tournament - Confirmation",
+    "description": "You are about to leave team **PLACEHOLDER_TEAM_NAME**.\n\n**What will happen:**",
+    "color": "0xFF9800",
+    "fields": [
+      {
+        "name": "📋 Consequences",
+        "value": "PLACEHOLDER_CONSEQUENCES",
+        "inline": false
+      },
+      {
+        "name": "✅ Safe to Leave",
+        "value": "Registration is still open, so there are no penalties for leaving now.",
+        "inline": false
+      }
+    ],
+    "footer": "⏰ You have 60 seconds to decide."
+  },
+  "LEAVE_AFTER_REGISTRATION": {
+    "title": "🚨 Leave Tournament - WARNING",
+    "description": "You are about to leave team **PLACEHOLDER_TEAM_NAME**.\n\n**⚠️ SERIOUS CONSEQUENCES - READ CAREFULLY:**",
+    "color": "0xE74C3C",
+    "fields": [
+      {
+        "name": "⚠️ Consequences",
+        "value": "PLACEHOLDER_CONSEQUENCES",
+        "inline": false
+      },
+      {
+        "name": "👥 Impact on Partner",
+        "value": "PLACEHOLDER_PARTNER_IMPACT",
+        "inline": false
+      },
+      {
+        "name": "🛑 Are you absolutely sure?",
+        "value": "Only proceed if you cannot continue playing in this tournament.\nConsider discussing with your partner first if applicable.",
+        "inline": false
+      }
+    ],
+    "footer": "⏰ You have 60 seconds to decide."
+  },
+  "MESSAGES": {
+    "consequences_team_dissolved": "🔹 Your team will be **dissolved**",
+    "consequences_partner_solo": "🔹 Your partner (PLACEHOLDER_PARTNER) will be moved to the **solo queue**",
+    "consequences_partner_rematched": "🔹 They may be matched with another solo player",
+    "consequences_removed": "🔹 You will be **completely removed** from the tournament",
+    "consequences_can_rejoin": "🔹 You can **re-register** at any time before registration closes",
+    "consequences_withdrawn": "🔹 Your team will be marked as **WITHDRAWN**",
+    "consequences_forfeited": "🔹 **PLACEHOLDER_MATCH_COUNT match(es)** will be **forfeited**",
+    "consequences_auto_loss": "🔹 All forfeited matches count as **automatic losses**",
+    "consequences_auto_win": "🔹 Your opponents will receive **automatic wins**",
+    "consequences_partner_eliminated": "🔹 Your partner (PLACEHOLDER_PARTNER) will also be **eliminated**",
+    "consequences_irreversible": "🔹 This action **CANNOT BE UNDONE**",
+    "consequences_no_rejoin": "🔹 You **CANNOT re-join** this tournament",
+    "partner_impact_text": "Your partner will be notified and the entire team will be withdrawn.\nBoth of you will be removed from the tournament.",
+    "partner_impact_none": "Your entire team will be removed from the tournament.",
+    "button_confirm": "✅ Yes, Leave Tournament",
+    "button_cancel": "❌ Cancel",
+    "confirm_left": "✅ You have successfully left team **PLACEHOLDER_TEAM_NAME**.",
+    "confirm_left_forfeited": "✅ You have left team **PLACEHOLDER_TEAM_NAME**.\n⚠️ The team has been withdrawn and **PLACEHOLDER_MATCH_COUNT match(es)** forfeited.",
+    "cancelled": "❌ Leave operation cancelled.",
+    "already_cancelled": "✅ Cancelled. You remain in the tournament.",
+    "timeout": "⌛ Leave confirmation timed out. You remain in the tournament.",
+    "only_initiator": "🚫 Only the person who initiated this can confirm.",
+    "only_initiator_cancel": "🚫 Only the person who initiated this can cancel.",
+    "partner_notification": "⚠️ PLACEHOLDER_PARTNER: Your teammate has left the tournament. Team **PLACEHOLDER_TEAM_NAME** has been withdrawn and all matches forfeited."
+  }
+}


### PR DESCRIPTION
Added translation templates for:
- Leave confirmation dialog (during/after registration)
- Availability conflict resolution system

Templates include:
- All embed titles, descriptions, fields
- All button labels and messages
- All user-facing strings
- Complete German translations

Note: Python views still use hardcoded strings.
Full refactoring to use these templates is pending.