### PR TITLE
Refactor: Integrate locale system into player stats

### DIFF
--- a/locale/de/embeds/player_stats.json
+++ b/locale/de/embeds/player_stats.json
@@ -1,0 +1,61 @@
+{
+  "PLAYER_STATS_EMBED": {
+    "title": "📊 Statistiken für PLACEHOLDER_PLAYER_NAME",
+    "description": "━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+    "color": "0x3498DB",
+    "footer": "Spieler seit PLACEHOLDER_PLAYER_SINCE"
+  },
+  "FIELD_LABELS": {
+    "tournament_record": "🏆 Turnierrekord",
+    "match_record": "⚔️ Match-Rekord",
+    "streaks": "🔥 Serien",
+    "per_game_stats": "━━━━ Pro-Spiel Stats ━━━━",
+    "rivals": "👥 Rivalen",
+    "activity": "📅 Aktivität"
+  },
+  "STAT_LABELS": {
+    "wins": "Siege",
+    "played": "Gespielt",
+    "winrate": "Siegrate",
+    "total": "Gesamt",
+    "current": "Aktuell",
+    "best": "Beste",
+    "nemesis": "Erzfeind",
+    "favorite_rival": "Lieblingsrivale",
+    "last_tournament": "Letztes Turnier",
+    "last_game": "Letztes Spiel"
+  },
+  "MESSAGES": {
+    "no_games_played": "Noch keine Spiele gespielt",
+    "no_nemesis": "–",
+    "no_rival": "–",
+    "never": "Nie",
+    "win_singular": "Sieg",
+    "wins_plural": "Siege",
+    "loss_singular": "Niederlage",
+    "losses_plural": "Niederlagen",
+    "unknown": "Unbekannt"
+  },
+  "TIME_FORMAT": {
+    "less_than_hour": "Vor weniger als einer Stunde",
+    "hour_singular": "Vor PLACEHOLDER_COUNT Stunde",
+    "hours_plural": "Vor PLACEHOLDER_COUNT Stunden",
+    "yesterday": "Gestern",
+    "day_singular": "Vor PLACEHOLDER_COUNT Tag",
+    "days_plural": "Vor PLACEHOLDER_COUNT Tagen",
+    "week_singular": "Vor PLACEHOLDER_COUNT Woche",
+    "weeks_plural": "Vor PLACEHOLDER_COUNT Wochen",
+    "month_singular": "Vor PLACEHOLDER_COUNT Monat",
+    "months_plural": "Vor PLACEHOLDER_COUNT Monaten",
+    "year_singular": "Vor PLACEHOLDER_COUNT Jahr",
+    "years_plural": "Vor PLACEHOLDER_COUNT Jahren"
+  },
+  "VALUE_TEMPLATES": {
+    "tournament_record": "**PLACEHOLDER_LABEL_WINS:** PLACEHOLDER_WINS\n**PLACEHOLDER_LABEL_PLAYED:** PLACEHOLDER_PARTICIPATIONS\n**PLACEHOLDER_LABEL_WINRATE:** PLACEHOLDER_WINRATE",
+    "match_record": "**PLACEHOLDER_MATCH_WINS W - PLACEHOLDER_MATCH_LOSSES L**\n**PLACEHOLDER_LABEL_TOTAL:** PLACEHOLDER_TOTAL_MATCHES\n**PLACEHOLDER_LABEL_WINRATE:** PLACEHOLDER_MATCH_WINRATE",
+    "streaks": "**PLACEHOLDER_LABEL_CURRENT:** PLACEHOLDER_CURRENT_STREAK\n**PLACEHOLDER_LABEL_BEST:** PLACEHOLDER_BEST_STREAK PLACEHOLDER_WINS_TEXT",
+    "game_stat_line": "🎯 **PLACEHOLDER_GAME**: PLACEHOLDER_WINS W-PLACEHOLDER_LOSSES L (PLACEHOLDER_WINRATE %)",
+    "rivals": "**PLACEHOLDER_LABEL_NEMESIS:** PLACEHOLDER_NEMESIS\n**PLACEHOLDER_LABEL_RIVAL:** PLACEHOLDER_RIVAL",
+    "activity": "**PLACEHOLDER_LABEL_LAST_TOURNAMENT:** PLACEHOLDER_LAST_TOURNAMENT\n**PLACEHOLDER_LABEL_LAST_GAME:** PLACEHOLDER_LAST_GAME"
+  }
+}

--- a/locale/en/embeds/player_stats.json
+++ b/locale/en/embeds/player_stats.json
@@ -1,0 +1,61 @@
+{
+  "PLAYER_STATS_EMBED": {
+    "title": "📊 Statistics for PLACEHOLDER_PLAYER_NAME",
+    "description": "━━━━━━━━━━━━━━━━━━━━━━━━━━━━",
+    "color": "0x3498DB",
+    "footer": "Player since PLACEHOLDER_PLAYER_SINCE"
+  },
+  "FIELD_LABELS": {
+    "tournament_record": "🏆 Tournament Record",
+    "match_record": "⚔️ Match Record",
+    "streaks": "🔥 Streaks",
+    "per_game_stats": "━━━━ Per-Game Stats ━━━━",
+    "rivals": "👥 Rivals",
+    "activity": "📅 Activity"
+  },
+  "STAT_LABELS": {
+    "wins": "Wins",
+    "played": "Played",
+    "winrate": "Winrate",
+    "total": "Total",
+    "current": "Current",
+    "best": "Best",
+    "nemesis": "Nemesis",
+    "favorite_rival": "Favorite Rival",
+    "last_tournament": "Last Tournament",
+    "last_game": "Last Game"
+  },
+  "MESSAGES": {
+    "no_games_played": "No games played yet",
+    "no_nemesis": "–",
+    "no_rival": "–",
+    "never": "Never",
+    "win_singular": "Win",
+    "wins_plural": "Wins",
+    "loss_singular": "Loss",
+    "losses_plural": "Losses",
+    "unknown": "Unknown"
+  },
+  "TIME_FORMAT": {
+    "less_than_hour": "Less than an hour ago",
+    "hour_singular": "PLACEHOLDER_COUNT hour ago",
+    "hours_plural": "PLACEHOLDER_COUNT hours ago",
+    "yesterday": "Yesterday",
+    "day_singular": "PLACEHOLDER_COUNT day ago",
+    "days_plural": "PLACEHOLDER_COUNT days ago",
+    "week_singular": "PLACEHOLDER_COUNT week ago",
+    "weeks_plural": "PLACEHOLDER_COUNT weeks ago",
+    "month_singular": "PLACEHOLDER_COUNT month ago",
+    "months_plural": "PLACEHOLDER_COUNT months ago",
+    "year_singular": "PLACEHOLDER_COUNT year ago",
+    "years_plural": "PLACEHOLDER_COUNT years ago"
+  },
+  "VALUE_TEMPLATES": {
+    "tournament_record": "**PLACEHOLDER_LABEL_WINS:** PLACEHOLDER_WINS\n**PLACEHOLDER_LABEL_PLAYED:** PLACEHOLDER_PARTICIPATIONS\n**PLACEHOLDER_LABEL_WINRATE:** PLACEHOLDER_WINRATE",
+    "match_record": "**PLACEHOLDER_MATCH_WINS W - PLACEHOLDER_MATCH_LOSSES L**\n**PLACEHOLDER_LABEL_TOTAL:** PLACEHOLDER_TOTAL_MATCHES\n**PLACEHOLDER_LABEL_WINRATE:** PLACEHOLDER_MATCH_WINRATE",
+    "streaks": "**PLACEHOLDER_LABEL_CURRENT:** PLACEHOLDER_CURRENT_STREAK\n**PLACEHOLDER_LABEL_BEST:** PLACEHOLDER_BEST_STREAK PLACEHOLDER_WINS_TEXT",
+    "game_stat_line": "🎯 **PLACEHOLDER_GAME**: PLACEHOLDER_WINS W-PLACEHOLDER_LOSSES L (PLACEHOLDER_WINRATE %)",
+    "rivals": "**PLACEHOLDER_LABEL_NEMESIS:** PLACEHOLDER_NEMESIS\n**PLACEHOLDER_LABEL_RIVAL:** PLACEHOLDER_RIVAL",
+    "activity": "**PLACEHOLDER_LABEL_LAST_TOURNAMENT:** PLACEHOLDER_LAST_TOURNAMENT\n**PLACEHOLDER_LABEL_LAST_GAME:** PLACEHOLDER_LAST_GAME"
+  }
+}


### PR DESCRIPTION
Made player statistics fully locale-compatible:

**Locale Templates (DE + EN):**
- locale/de/embeds/player_stats.json - German translations
- locale/en/embeds/player_stats.json - English translations
- All field labels, stat labels, and messages localized
- Time formatting with proper singular/plural handling

**Refactored Modules:**
- stats_tracker.py: format_time_since() now locale-aware
  - Supports all time units (hours, days, weeks, months, years)
  - Proper singular/plural handling per language
  - Uses TIME_FORMAT templates from locale files

- info.py: build_stats_embed() fully locale-integrated
  - All hardcoded strings replaced with locale templates
  - Field names, stat labels, messages from templates
  - Maintains all functionality (Nemesis, Streaks, etc.)

**German Translations:**
- "Turnierrekord" (Tournament Record)
- "Match-Rekord" (Match Record)
- "Serien" (Streaks)
- "Erzfeind" (Nemesis)
- "Lieblingsrivale" (Favorite Rival)
- Time formats: "Vor X Tagen", "Gestern", etc.

**Backward Compatible:**
- English fallbacks for all templates
- Works with existing stats data
- No breaking changes