### PR TITLE
Refactor: Migrate player stats from centralized to file-based storage

### DIFF
--- a/modules/archive.py
+++ b/modules/archive.py
@@ -69,13 +69,16 @@ def update_tournament_history(winner_ids: list[str], chosen_game: str, mvp_name:
                 logger.warning("[HISTORY] tournament_history.json corrupted. Creating new file.")
                 history_data = []
 
-    # Get winner names from global_data
-    global_data = load_global_data()
-    player_stats = global_data.get("player_stats", {})
+    # Get winner names from player stats files
+    from modules.stats_tracker import load_player_stats
 
     winners = []
     for user_id in winner_ids:
-        name = player_stats.get(user_id, {}).get("name", f"<@{user_id}>")
+        stats = load_player_stats(user_id)
+        if stats:
+            name = stats.get("display_name", f"<@{user_id}>")
+        else:
+            name = f"<@{user_id}>"
         winners.append(name)
 
     # Tournament entry

--- a/modules/tournament.py
+++ b/modules/tournament.py
@@ -42,11 +42,11 @@ from modules.info import (
     get_mvp,
     get_winner_ids,
     get_winner_team,
-    update_player_stats,
 )
 from modules.stats_tracker import (
     record_match_result,
-    update_tournament_participation
+    update_tournament_participation,
+    update_tournament_wins
 )
 from modules.task_manager import add_task
 from modules.utils import (
@@ -57,7 +57,6 @@ from modules.utils import (
     get_player_team,
     has_permission,
     smart_send,
-    update_all_participants,
 )
 
 # Global variables for double-call prevention
@@ -107,9 +106,6 @@ async def end_tournament_procedure(
         match = re.search(r"\d+", mvp)  # MVP could be a mention like <@1234567890>
         if match:
             new_champion_id = int(match.group(0))
-
-    updated_count = await update_all_participants()
-    logger.info(f"[TOURNAMENT] {updated_count} participant statistics updated.")
 
     # Process all completed matches for detailed stats
     try:
@@ -168,11 +164,11 @@ async def end_tournament_procedure(
     except Exception as e:
         logger.error(f"[STATS] Error updating tournament participation: {e}", exc_info=True)
 
-    if winner_ids and chosen_game != "Unknown":
-        update_player_stats(winner_ids, chosen_game)
+    if winner_ids:
+        update_tournament_wins(winner_ids)
         logger.info(f"[TOURNAMENT] Winners saved: {winner_ids} for game: {chosen_game}")
     else:
-        logger.warning("[TOURNAMENT] No winners or game name found.")
+        logger.warning("[TOURNAMENT] No winners found.")
 
     update_tournament_history(
         winner_ids=winner_ids,

--- a/modules/utils.py
+++ b/modules/utils.py
@@ -461,17 +461,22 @@ def get_team_open_matches(team_name: str) -> list:
 
 async def autocomplete_players(interaction: Interaction, current: str):
     """Autocomplete function for player selection."""
+    from modules.stats_tracker import list_all_players, load_player_stats
+
     logger.info(f"[AUTOCOMPLETE] Called – Input: {current}")
-    global_data = load_global_data()
-    player_stats = global_data.get("player_stats", {})
+    player_ids = list_all_players()
 
     choices = []
-    for user_id, stats in player_stats.items():
+    for user_id in player_ids:
+        stats = load_player_stats(user_id)
+        if not stats:
+            continue
+
         member = interaction.guild.get_member(int(user_id))
         if member:
             display_name = member.display_name
         else:
-            display_name = stats.get("display_name") or stats.get("name") or f"Unknown ({user_id})"
+            display_name = stats.get("display_name") or f"Unknown ({user_id})"
 
         if current.lower() in display_name.lower():
             choices.append(app_commands.Choice(name=display_name, value=user_id))


### PR DESCRIPTION
Major architectural change for GDPR compliance and scalability:
- Each player now has individual stats file (data/player_stats/{user_id}.json)
- Benefits: Easy data deletion, better performance, no O(n²) growth
- No migration script needed (no production data yet)

Changes:
- stats_tracker.py: Add file-based load/save/delete functions
- stats_tracker.py: Add update_tournament_wins() for winners tracking
- info.py: Update all commands to use file-based stats
- tournament.py: Switch to new stats functions
- admin_tools.py: Update add_win command
- archive.py: Update to load from player files
- utils.py: Update autocomplete_players function

Removed deprecated centralized storage calls throughout codebase.