### PR TITLE
feat: show connected servers in startup log

### DIFF
--- a/modules/main.py
+++ b/modules/main.py
@@ -55,6 +55,17 @@ async def on_ready():
     logger.info("═" * 70)
     logger.info(f"[STARTUP] 🤖 Bot: {bot.user.name} (ID: {bot.user.id})")
     logger.info(f"[STARTUP] 🌍 Language: {language} | DEBUG: {'ON' if DEBUG_MODE else 'OFF'}")
+
+    # Show connected servers
+    if len(bot.guilds) == 0:
+        logger.warning("[STARTUP] ⚠️  Servers: Not connected to any server!")
+    elif len(bot.guilds) == 1:
+        guild = bot.guilds[0]
+        logger.info(f"[STARTUP] 🏠 Server: {guild.name} ({len(guild.members)} members)")
+    else:
+        guild_names = ", ".join([f"{g.name}" for g in bot.guilds])
+        logger.info(f"[STARTUP] 🏠 Servers: {len(bot.guilds)} ({guild_names})")
+
     logger.info("═" * 70)
 
     # Check important folders (only log errors or creation)


### PR DESCRIPTION
Added server information to startup output (not just DEBUG mode):
- Single server: Shows name and member count
- Multiple servers: Shows count and all server names
- No servers: Shows warning

This makes it immediately visible which Discord server(s) the bot is connected to, which is important for troubleshooting.