### PR TITLE
Update game key feature: only overall winner team can claim, with aut…

### DIFF
--- a/locale/de/embeds/keys.json
+++ b/locale/de/embeds/keys.json
@@ -1,0 +1,32 @@
+{
+  "KEY_DONATION_SUCCESS": {
+    "title": "✅ Key erfolgreich gespendet",
+    "description": "Vielen Dank für deine Spende!\n\n**Beschreibung:** PLACEHOLDER_DESCRIPTION",
+    "color": "0x57F287",
+    "footer": "Dein Key wurde verschlüsselt und sicher gespeichert."
+  },
+  "KEY_WINNER_NOTIFICATION": {
+    "title": "🎉 Glückwunsch zum Turniersieg!",
+    "description": "**Team PLACEHOLDER_TEAM_NAME** hat das Turnier gewonnen!\n\n🎁 **Gute Neuigkeiten!** Es gibt **PLACEHOLDER_KEY_COUNT** Game Keys für euch zum Claimen.\n\nNutze `/key claim` um deinen Key abzuholen!",
+    "color": "0xFFD700",
+    "fields": [
+      {
+        "name": "Verfügbare Keys",
+        "value": "PLACEHOLDER_KEY_LIST"
+      }
+    ],
+    "footer": "Jedes Teammitglied kann einen Key claimen. Keys werden per DM zugeschickt."
+  },
+  "KEY_CLAIM_SELECT": {
+    "title": "🎁 Wähle einen Game Key",
+    "description": "Klicke auf einen Button unten, um einen Key zu claimen. Der Key wird dir per DM zugeschickt.",
+    "color": "0xFFD700",
+    "footer": "Du kannst nur einen Key pro Turnier claimen."
+  },
+  "KEY_CLAIMED_SUCCESS": {
+    "title": "🎁 Dein Game Key",
+    "description": "**Beschreibung:** PLACEHOLDER_DESCRIPTION\n**Key:** `PLACEHOLDER_KEY`",
+    "color": "0xFFD700",
+    "footer": "Herzlichen Glückwunsch zum Sieg! 🎉"
+  }
+}

--- a/locale/en/embeds/keys.json
+++ b/locale/en/embeds/keys.json
@@ -1,0 +1,32 @@
+{
+  "KEY_DONATION_SUCCESS": {
+    "title": "✅ Key Donated Successfully",
+    "description": "Thank you for your donation!\n\n**Description:** PLACEHOLDER_DESCRIPTION",
+    "color": "0x57F287",
+    "footer": "Your key has been encrypted and stored securely."
+  },
+  "KEY_WINNER_NOTIFICATION": {
+    "title": "🎉 Congratulations on Winning the Tournament!",
+    "description": "**Team PLACEHOLDER_TEAM_NAME** has won the tournament!\n\n🎁 **Good news!** There are **PLACEHOLDER_KEY_COUNT** game keys available for you to claim.\n\nUse `/key claim` to claim your key!",
+    "color": "0xFFD700",
+    "fields": [
+      {
+        "name": "Available Keys",
+        "value": "PLACEHOLDER_KEY_LIST"
+      }
+    ],
+    "footer": "Each team member can claim one key. Keys will be sent via DM."
+  },
+  "KEY_CLAIM_SELECT": {
+    "title": "🎁 Claim a Game Key",
+    "description": "Click a button below to claim a key. The key will be sent to you via DM.",
+    "color": "0xFFD700",
+    "footer": "You can only claim one key per tournament."
+  },
+  "KEY_CLAIMED_SUCCESS": {
+    "title": "🎁 Your Game Key",
+    "description": "**Description:** PLACEHOLDER_DESCRIPTION\n**Key:** `PLACEHOLDER_KEY`",
+    "color": "0xFFD700",
+    "footer": "Congratulations on your win! 🎉"
+  }
+}

--- a/locale/nl/embeds/keys.json
+++ b/locale/nl/embeds/keys.json
@@ -1,0 +1,32 @@
+{
+  "KEY_DONATION_SUCCESS": {
+    "title": "✅ Key succesvol gedoneerd",
+    "description": "Bedankt voor je donatie!\n\n**Beschrijving:** PLACEHOLDER_DESCRIPTION",
+    "color": "0x57F287",
+    "footer": "Je key is versleuteld en veilig opgeslagen."
+  },
+  "KEY_WINNER_NOTIFICATION": {
+    "title": "🎉 Gefeliciteerd met de toernooiwinst!",
+    "description": "**Team PLACEHOLDER_TEAM_NAME** heeft het toernooi gewonnen!\n\n🎁 **Goed nieuws!** Er zijn **PLACEHOLDER_KEY_COUNT** game keys beschikbaar om te claimen.\n\nGebruik `/key claim` om je key op te halen!",
+    "color": "0xFFD700",
+    "fields": [
+      {
+        "name": "Beschikbare Keys",
+        "value": "PLACEHOLDER_KEY_LIST"
+      }
+    ],
+    "footer": "Elk teamlid kan één key claimen. Keys worden via DM verzonden."
+  },
+  "KEY_CLAIM_SELECT": {
+    "title": "🎁 Claim een Game Key",
+    "description": "Klik op een knop hieronder om een key te claimen. De key wordt naar je gestuurd via DM.",
+    "color": "0xFFD700",
+    "footer": "Je kunt slechts één key per toernooi claimen."
+  },
+  "KEY_CLAIMED_SUCCESS": {
+    "title": "🎁 Jouw Game Key",
+    "description": "**Beschrijving:** PLACEHOLDER_DESCRIPTION\n**Key:** `PLACEHOLDER_KEY`",
+    "color": "0xFFD700",
+    "footer": "Gefeliciteerd met je overwinning! 🎉"
+  }
+}

--- a/modules/admin_tools.py
+++ b/modules/admin_tools.py
@@ -237,7 +237,7 @@ class AdminGroup(app_commands.Group):
             ephemeral=True,
         )
 
-        await end_tournament_procedure(interaction.channel, manual_trigger=True)
+        await end_tournament_procedure(interaction.channel, manual_trigger=True, bot=interaction.client)
 
 
     @app_commands.command(name="manage_game", description="Add or remove a game.")

--- a/modules/tournament.py
+++ b/modules/tournament.py
@@ -72,6 +72,7 @@ async def end_tournament_procedure(
     channel: discord.TextChannel,
     manual_trigger: bool = False,
     interaction: Optional[Interaction] = None,
+    bot: Optional[discord.Client] = None,
 ):
     """
     Handles the tournament end procedure:
@@ -197,6 +198,16 @@ async def end_tournament_procedure(
     # Send final embed (before reset, so chosen_game is available)
     mvp_message = f"🏆 Tournament MVP: **{mvp}**!" if mvp else "🏆 No MVP determined."
     await send_tournament_end_announcement(channel, mvp_message, winner_ids, chosen_game, new_champion_id)
+
+    # Notify winners about available game keys
+    if bot and winner_ids:
+        try:
+            winning_team_name = get_winner_team(winner_ids)
+            if winning_team_name:
+                from modules.key_manager import notify_winners_about_keys
+                await notify_winners_about_keys(bot, winner_ids, winning_team_name)
+        except Exception as e:
+            logger.error(f"[TOURNAMENT] Error notifying winners about keys: {e}")
 
     if mvp:  # If MVP exists
         try:


### PR DESCRIPTION
…omatic notifications

Changes:
- Only tournament overall winner team (most wins) can claim keys
- Keys only claimable after tournament ends (running check)
- Winners are automatically notified via DM when tournament ends
- All embeds now use locale/ templates for multi-language support

Embed Templates:
- Added locale/de/embeds/keys.json (German)
- Added locale/en/embeds/keys.json (English)
- Added locale/nl/embeds/keys.json (Dutch)
- Templates: KEY_DONATION_SUCCESS, KEY_WINNER_NOTIFICATION, KEY_CLAIM_SELECT, KEY_CLAIMED_SUCCESS

Integration:
- notify_winners_about_keys() called automatically in end_tournament_procedure()
- Sends DM to each winner with available keys list
- Graceful handling of DM failures

Updated Files:
- modules/key_manager.py: Added tournament end check, locale integration, notification function
- modules/tournament.py: Added bot parameter to end_tournament_procedure, integrated key notification
- modules/admin_tools.py: Pass bot instance to end_tournament_procedure