### PR TITLE
Improve key claiming robustness: prevent duplicate claims per tournament

### DIFF
--- a/modules/utils.py
+++ b/modules/utils.py
@@ -367,6 +367,7 @@ def finalize_tournament(winning_team: str, winners: list[int], game: str, points
         "points": points,
         "game": game,
         "ended_at": datetime.now(tz=ZoneInfo(CONFIG.bot.timezone)).isoformat(),
+        "winner_ids": [str(uid) for uid in winners],  # Store winner IDs for key claiming
     }
 
     # Increase stats


### PR DESCRIPTION
CRITICAL FIX: Robust duplicate claim prevention
- Keys are now tracked per tournament using tournament_id (ended_at timestamp)
- New claims_per_tournament structure in game_keys.json prevents duplicate claims
- Users can claim one key per tournament, even if weeks pass between tournaments

Changes:
1. Data Structure:
   - Added claims_per_tournament to game_keys.json
   - Tracks user claims by tournament_id for robust validation
   - Each claim stores: claimed_at, key_id

2. Claim Validation:
   - Uses last_tournament_winner from global data (persists after tournament reset)
   - Checks winner_ids from last_tournament_winner.winner_ids
   - Validates against claims_per_tournament[tournament_id][user_id]
   - Multiple layers of protection against duplicate claims

3. Key Donation:
   - Keys can be donated at ANY time (not just during tournaments)
   - No tournament checks on /key donate command

4. Data Persistence:
   - utils.py: Store winner_ids in last_tournament_winner
   - ClaimKeyView: Updated to use tournament_id and winner_ids
   - Rollback logic updated to clean claims_per_tournament on DM failure

Benefits:
- Prevents double-claiming even if weeks/months pass between tournaments
- Survives tournament data reset
- Clear audit trail per tournament
- Backwards compatible (auto-adds claims_per_tournament if missing)

Files Changed:
- modules/key_manager.py: Complete claim logic overhaul
- modules/utils.py: Store winner_ids in last_tournament_winner
- data/game_keys.json: Add claims_per_tournament structure